### PR TITLE
prepare 1.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,22 @@
 # Changelog
 
-This changelog starts with the currently maintained release-candidate line. It
-does not reconstruct older release notes or infer publication dates from Git
-history. Git history remains the record for earlier development snapshots.
+This changelog starts with the currently maintained release line. It does not
+reconstruct older release notes or infer publication dates from Git history.
+Git history remains the record for earlier development snapshots.
 
 ## Unreleased
 
 Changes intended for the next published version must be summarized here before
 release. Do not treat an entry in this section as shipped behavior.
 
-## 1.5.0 — release candidate
+## 1.5.0
 
-`1.5.0` is the version currently aligned across the Python project, package,
-lockfiles, GUI package, and release-artifact workflow. Its implemented scope,
-validation contract, and remaining environment gates are maintained in
+`1.5.0` is the current release version aligned across the Python project,
+package lockfiles, GUI package, and release-artifact workflow. Its implemented
+scope, validation contract, and remaining environment gates are maintained in
 [docs/release_status.md](docs/release_status.md).
 
-This candidate preserves Manifest v1/v2 governed Tools compatibility and adds
+This release preserves Manifest v1/v2 governed Tools compatibility and adds
 the exact-`2026-07-28` Manifest v3 client for governed Tools, Resources,
 Resource Templates, Prompts, Completion, Host-owned OAuth, MRTR, pinned remote
 Tasks, and bounded subscriptions. It also introduces the explicit RuntimeStore
@@ -24,9 +24,11 @@ schema-v6-to-v7 migration and tightens Tool argument, deadline, redaction,
 retry-classification, registry-search, artifact, and cross-SDK conformance
 contracts.
 
-This heading does not claim that a tag, PyPI upload, GitHub release, or current
-CI receipt exists. Publication requires the separately authorized process in
-[docs/releasing.md](docs/releasing.md).
+The tag, GitHub Release, and downloadable Python artifacts must remain bound to
+the exact source commit, CI receipt, and checksums recorded by the separately
+authorized process in [docs/releasing.md](docs/releasing.md). This entry does
+not claim a PyPI upload, signed desktop distribution, or completion of the
+environment gates listed in the release status.
 
 ## 1.4.2 — prior release candidate
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,5 +22,6 @@ material you are authorized to share under the repository's Apache-2.0 license.
 Ordinary bugs and feature proposals may use GitHub issues. Suspected security
 vulnerabilities, exploit details, secrets, and private data must follow the
 reporting guidance in [SECURITY.md](SECURITY.md), not a public issue or pull
-request. While no confidential intake is enabled, a public issue may contain
-only the non-sensitive coordination request that policy permits.
+request. Use the private-report form linked from that policy. If the form is
+unavailable, a public issue may contain only the non-sensitive coordination
+request that policy permits.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The implementation currently includes:
 
 Start here, then read the deeper references as needed:
 
-- [docs/release_status.md](https://github.com/yingqi-z20/Agent-libOS/blob/main/docs/release_status.md): current-version candidate scope,
+- [docs/release_status.md](https://github.com/yingqi-z20/Agent-libOS/blob/main/docs/release_status.md): current-version release scope,
   validation contract, and remaining environment boundaries (not a CI receipt).
 - [docs/python_api.md](https://github.com/yingqi-z20/Agent-libOS/blob/main/docs/python_api.md): public Python imports, Runtime
   lifecycle, manager properties, sync/async usage, exceptions, and
@@ -287,7 +287,7 @@ Start here, then read the deeper references as needed:
   reporting availability, coordinated disclosure, and safe research guidance.
 - [CONTRIBUTING.md](https://github.com/yingqi-z20/Agent-libOS/blob/main/CONTRIBUTING.md): contribution scope, testing expectations,
   pull-request evidence, and security-report routing.
-- [CHANGELOG.md](https://github.com/yingqi-z20/Agent-libOS/blob/main/CHANGELOG.md): release-candidate history without implying an
+- [CHANGELOG.md](https://github.com/yingqi-z20/Agent-libOS/blob/main/CHANGELOG.md): release history without implying an
   unverified tag, upload, or publication date.
 - [AGENTS.md](https://github.com/yingqi-z20/Agent-libOS/blob/main/AGENTS.md): repository structure, testing, security, and
   contribution guidance for local agents and contributors.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ corruption, containment failure, or vulnerable dependency are welcome.
 
 | Version | Current evidence and handling |
 | --- | --- |
-| Current `main` and the 1.5.0 release-candidate line | Target of current checked-in validation and best-effort fixes |
+| Current `main` and the 1.5.x release line | Target of current checked-in validation and best-effort fixes |
 | 1.4.x and older snapshots | No current validation or fix commitment; handling is decided per report |
 
 This table records repository evidence, not an owner-approved long-term support
@@ -19,25 +19,22 @@ range for the specific report.
 
 ## Confidential reporting status
 
-GitHub private vulnerability reporting is currently **not enabled** for this
-repository. Consequently, the standard
-[private-report URL](https://github.com/yingqi-z20/Agent-libOS/security/advisories/new)
-is not presently a working intake channel. This policy deliberately does not
-invent an email address or imply that another confidential channel exists.
+GitHub private vulnerability reporting is **enabled** for this repository. A
+repository owner confirmed the setting before the 1.5.0 release. Signed-in
+reporters should use the standard
+[private-report form](https://github.com/yingqi-z20/Agent-libOS/security/advisories/new)
+for vulnerability facts, exploit details, credentials, private data, or a
+proof of concept.
 
-Until a maintainer enables private reporting, do not put vulnerability facts,
-exploit details, credentials, private data, or a proof of concept in an issue,
-discussion, pull request, commit, or other public location. You may open a
+Do not put sensitive security-report content in an issue, discussion, pull
+request, commit, or other public location. If the private-report form becomes
+unavailable, retain the report privately and open a
 [GitHub issue](https://github.com/yingqi-z20/Agent-libOS/issues/new) containing
-only a non-sensitive request for the maintainers to establish a private
-security contact. The request must not identify the affected component,
-version, weakness, prerequisites, impact, or reproduction. Otherwise, retain
-the report privately and wait for a confidential channel.
-
-After the repository Security page visibly offers private vulnerability
-reporting, use the private-report URL above. Maintainers must update this status
-when they enable and verify that channel; enabling it is a release blocker in
-[the release runbook](docs/releasing.md).
+only a non-sensitive request for the maintainers to restore the confidential
+channel. The request must not identify the affected component, version,
+weakness, prerequisites, impact, or reproduction. This policy deliberately
+does not invent an email address or imply that another confidential channel
+exists.
 
 Include, when available:
 

--- a/docs/release_status.md
+++ b/docs/release_status.md
@@ -1,13 +1,13 @@
 # Agent libOS 1.5.0 Status
 
-Agent libOS 1.5.0 is a release candidate for the core Python runtime scope
-defined in `docs/support_matrix.md`. Release-ready status for any source tree is
+Agent libOS 1.5.0 is the current release line for the core Python runtime scope
+defined in `docs/support_matrix.md`. Release status for any source tree is
 conditional on that exact tree passing the checked-in CI workflow; local
 deterministic results do not substitute for its Python-version, PostgreSQL, and
 artifact gates. This is not a claim that every platform, desktop package, or
 real external-provider configuration has been release-validated.
 
-This page records the candidate scope and the checked-in validation contract;
+This page records the release scope and the checked-in validation contract;
 it is not itself a CI receipt. A release-pass claim must be bound to all of the
 following immutable locators:
 
@@ -18,7 +18,7 @@ following immutable locators:
 
 Without that complete binding, wording below such as “requires”, “gates”, or
 “checks” describes the workflow contract only, not an observed pass for a
-checkout or candidate artifact.
+checkout or release artifact.
 
 ## Implemented release safeguards
 
@@ -421,9 +421,9 @@ checkout or candidate artifact.
   contract files in the wheel, and requires the reviewed examples, scripts, and
   frozen Python/TypeScript fixture sources in the sdist. The build waits for its
   declared pre-build gates; these
-  smoke jobs run afterward, and the candidate is not release-validated until
+  smoke jobs run afterward, and the artifacts are not release-validated until
   the full downstream matrix succeeds. No workflow publishes or pushes
-  candidate distributions.
+  distributions.
 
 ## Unarchived real-LLM observation
 

--- a/tests/unit/test_release_contract.py
+++ b/tests/unit/test_release_contract.py
@@ -610,7 +610,7 @@ def test_release_status_requires_an_immutable_ci_receipt_binding() -> None:
         "the exact source commit locator",
         "the CI workflow run locator and the required job locators",
         "checksum-manifest artifact locators",
-        "not an observed pass for a checkout or candidate artifact",
+        "not an observed pass for a checkout or release artifact",
         "## Validation contract (CI receipt required)",
     ):
         assert required in normalized
@@ -1492,6 +1492,7 @@ def test_maintainer_governance_docs_match_current_release_boundaries() -> None:
     security_normalized = " ".join(security.split())
     contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
     changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    changelog_normalized = " ".join(changelog.split())
     releasing = (ROOT / "docs" / "releasing.md").read_text(encoding="utf-8")
     releasing_normalized = " ".join(releasing.split())
     version = tomllib.loads(
@@ -1500,13 +1501,16 @@ def test_maintainer_governance_docs_match_current_release_boundaries() -> None:
 
     for link in ("AGENTS.md", "docs/development.md", "SECURITY.md"):
         assert link in contributing
-    assert "only the non-sensitive coordination request" in contributing
+    assert "Use the private-report form linked from that policy" in contributing
+    assert "only the non-sensitive coordination" in contributing
 
     assert (
-        "private vulnerability reporting is currently **not enabled**"
+        "private vulnerability reporting is **enabled**"
         in security_normalized
     )
-    assert "is not presently a working intake channel" in security_normalized
+    assert "A repository owner confirmed the setting" in security_normalized
+    assert "Signed-in reporters should use the standard" in security_normalized
+    assert "private-report form" in security_normalized
     assert "only a non-sensitive request" in security_normalized
     assert "does not invent an email address" in security_normalized
     assert "No current validation or fix commitment" in security_normalized
@@ -1514,8 +1518,10 @@ def test_maintainer_governance_docs_match_current_release_boundaries() -> None:
     assert re.search(r"[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}", security) is None
 
     assert "## Unreleased" in changelog
-    assert f"## {version} — release candidate" in changelog
-    assert "does not claim that a tag, PyPI upload, GitHub release" in changelog
+    assert f"## {version}\n" in changelog
+    assert f"## {version} — release candidate" not in changelog
+    assert "does not claim a PyPI upload" in changelog_normalized
+    assert "signed desktop distribution" in changelog_normalized
 
     for required in (
         "read-only repository permission and no PyPI, tag, or GitHub-release authority",


### PR DESCRIPTION
## Summary

- record the verified GitHub private vulnerability-reporting channel
- promote the 1.5.0 documentation from release candidate to the current release line
- preserve explicit boundaries: no PyPI claim, no signed desktop claim, and no claim for unrun environment gates
- update the release governance regression contract to protect those facts

## Validation

- `uv run python -m pytest tests/unit/test_release_contract.py tests/unit/test_release_status_regressions.py -q` — 66 passed, 1 skipped (Windows symlink privilege unavailable)
- `uv run python -m pytest tests/unit/test_release_version_syntax.py -q` — 23 passed
- `git diff --check`

## Release process

This PR intentionally contains no product-code changes. After its exact squash
commit passes the complete `tests` workflow, the canonical wheel, sdist, and
`SHA256SUMS` from that run will be verified and attached to the authorized
`v1.5.0` GitHub Release. PyPI publication and internal unsigned desktop
packages are out of scope.
