### PR TITLE
Release 1.5.2

### DIFF
--- a/.github/workflows/desktop-internal.yml
+++ b/.github/workflows/desktop-internal.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 env:
-  AGENT_LIBOS_DESKTOP_VERSION: "1.5.1"
+  AGENT_LIBOS_DESKTOP_VERSION: "1.5.2"
   CSC_IDENTITY_AUTO_DISCOVERY: "false"
 
 jobs:
@@ -23,13 +23,13 @@ jobs:
         include:
           - runner: macos-15
             target: darwin-arm64
-            upload_name: agent-libos-1.5.1-macos-arm64-internal-unsigned
+            upload_name: agent-libos-1.5.2-macos-arm64-internal-unsigned
           - runner: windows-2025
             target: win32-x64
-            upload_name: agent-libos-1.5.1-windows-x64-internal-unsigned
+            upload_name: agent-libos-1.5.2-windows-x64-internal-unsigned
           - runner: ubuntu-24.04
             target: linux-x64
-            upload_name: agent-libos-1.5.1-linux-x64-internal-unsigned
+            upload_name: agent-libos-1.5.2-linux-x64-internal-unsigned
     name: ${{ matrix.target }} native package
     runs-on: ${{ matrix.runner }}
 
@@ -158,7 +158,7 @@ jobs:
       - name: Download all native artifact sets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: agent-libos-1.5.1-*-internal-unsigned-${{ github.sha }}-${{ github.run_attempt }}
+          pattern: agent-libos-1.5.2-*-internal-unsigned-${{ github.sha }}-${{ github.run_attempt }}
           path: downloaded-desktop
 
       - name: Verify each uploaded checksum manifest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 env:
-  RELEASE_WHEEL: dist/agent_libos-1.5.1-py3-none-any.whl
-  RELEASE_SDIST: dist/agent_libos-1.5.1.tar.gz
+  RELEASE_WHEEL: dist/agent_libos-1.5.2-py3-none-any.whl
+  RELEASE_SDIST: dist/agent_libos-1.5.2.tar.gz
   RELEASE_CHECKSUMS: dist/SHA256SUMS
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,13 @@ lives in `agent_libos/`, organized by subsystems including `runtime/`,
 `primitives/`, `capability/`, `memory/`, `skills/`, `modules/`, `tools/`,
 `substrate/`, `config/`, `evidence/`, `human/`, `images/`, `llm/`, `models/`,
 `ports/`, `sdk/`, `semantic/`, `storage/`, `utils/`, and `api/` for CLI/GUI server
-entrypoints. Pytest tests live in `tests/` and map to
+entrypoints. Pytest tests live in `tests/` and map to the six Python
 test matrix lanes: `unit`, `runtime`, `security`, `self-evolution`,
-`providers`, `benchmark`, and `gui`; some lane names differ from directory
+`providers`, and `benchmark`; some lane names differ from directory
 names, for example `self-evolution` maps to `tests/self_evolution` and
-`benchmark` maps to `tests/benchmarks`. Shared helpers live in
+`benchmark` maps to `tests/benchmarks`. The `gui` lane is not a pytest
+lane and has no `tests/` directory; it runs the frontend Vitest,
+typecheck, and build tooling in `gui/`. Shared helpers live in
 `tests/support/`. Runtime-safety task fixtures, runner implementations, oracle,
 and metrics live under `benchmarks/runtime_safety/`; practical evidence-level
 scenarios live under `benchmarks/practical_agent_workflows/`. User-facing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ Git history remains the record for earlier development snapshots.
 Changes intended for the next published version must be summarized here before
 release. Do not treat an entry in this section as shipped behavior.
 
+## 1.5.2
+
+`1.5.2` is the current stabilization release version aligned across the Python
+project, package lockfiles, GUI package, MCP client identity, desktop metadata,
+and release workflows. It builds on the 1.5.1 Runtime authority and data-flow
+semantics with further filesystem-authorization hardening, storage and recovery
+safety, generated-reference tooling, and a comprehensive documentation accuracy
+and completeness pass. As with every version entry here, publication still
+requires the separately authorized, receipt-bound process in
+[docs/releasing.md](docs/releasing.md); this entry alone does not claim a tag,
+package-index upload, signed desktop distribution, or completed external-provider
+gate.
+
+- Hardened filesystem authorization against path rebinding between
+  authorization and use.
+- Implemented runtime safety and recovery enhancements across the storage
+  factory and backend boundaries, checkpoint restore and snapshot remapping,
+  startup recovery, Git command policy, and Windows store identity handling.
+- Introduced the generated CLI reference, the generated configuration field
+  reference, and the version-pinned PyPI README generator, extracting the CLI
+  parser build for generated-reference use.
+- Fixed an ObjectTask wait race that could return a stale snapshot from
+  before the worker published its waiting notification, terminal result
+  collection in the ask-file-then-show example script, and a CI readiness
+  race in the GUI end-to-end suite.
+- Fixed documentation accuracy and completeness across the guide set. The
+  generated CLI reference now reports the effective destination default for
+  store-constant flags, and `task-run list --status` help and rejection
+  messages enumerate the closed status set.
+- Completed a comprehensive documentation review and remediation across the
+  guide set: corrected drifted inventories (MCP Resource surface, image
+  bindings, checkpoint images), documented the CLI exit-code contract and exec
+  image-package authority grant, fixed the storage migration backup example,
+  replaced stale version tokens, pinned the PyPI README quick-start clone to
+  the release tag, added help text for required CLI options, and added a
+  glossary version-map tripwire regression test.
+
 ## 1.5.1
 
 `1.5.1` is the current stabilization release version aligned across the Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,12 @@ gate.
 
 ## 1.5.1
 
-`1.5.1` is the current stabilization release version aligned across the Python
-project, package lockfiles, GUI package, MCP client identity, desktop metadata,
-and release workflows. It preserves the Runtime authority and data-flow
-semantics while hardening first-run behavior, offline migration reconciliation,
-terminal-owner cleanup, live-evaluation evidence recomputation, and release
-artifact validation.
+`1.5.1` was the preceding stabilization release version aligned across the
+Python project, package lockfiles, GUI package, MCP client identity, desktop
+metadata, and release workflows. It preserves the Runtime authority and
+data-flow semantics while hardening first-run behavior, offline migration
+reconciliation, terminal-owner cleanup, live-evaluation evidence recomputation,
+and release artifact validation.
 
 The source distribution now uses an explicit include/exclude partition. Its
 checker rejects ordinary source files outside that partition and validates the

--- a/README.md
+++ b/README.md
@@ -320,6 +320,19 @@ Tool Skills, and three console entry points: `agent-libos`,
 optional PTY module, and workspace Image/Skill packages remain checkout/source-
 archive assets rather than core-wheel contents.
 
+A published release version installs from a package index without a checkout:
+
+```bash
+pip install agent-libos
+# Optional integration extras mirror the source extras:
+pip install "agent-libos[mcp]"
+```
+
+A package install provides exactly the wheel contents and console entry points
+above. The repository assets listed above stay in the matching source checkout
+or source archive, and the package-index page's repository links point at that
+version's immutable `v<version>` tag rather than mutable `main`.
+
 Use the canonical page for every workflow beyond onboarding:
 
 | Task | Canonical page |

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -33,7 +33,7 @@ filesystem bypass for a process or model.
 
 This project is under active development. Current behavior is defined by the
 code and current-contract documents in the same checkout. Start with the
-[documentation home](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/index.md); historical design material is identified
+[documentation home](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/index.md); historical design material is identified
 separately below.
 
 ## 3 to 5 Minute Quick Start
@@ -43,7 +43,7 @@ no API credentials. It needs Python 3.11–3.14,
 [uv](https://docs.astral.sh/uv/), and a source checkout:
 
 ```bash
-git clone https://github.com/yingqi-z20/Agent-libOS.git
+git clone --branch v1.5.2 https://github.com/yingqi-z20/Agent-libOS.git
 cd Agent-libOS
 uv sync --frozen
 uv run agent-libos --db local demo
@@ -75,18 +75,18 @@ uv run python -c 'from pathlib import Path; Path("agent_outputs/demo_patch_previ
 
 The repository-wide `scripts/clean_agent_outputs.py` utility is broader: it
 previews, and with `--yes` removes, all ignored outputs under `agent_outputs/`.
-If setup or the demo fails, use [Troubleshooting](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/troubleshooting.md).
+If setup or the demo fails, use [Troubleshooting](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/troubleshooting.md).
 
 Choose the next path by role:
 
-- user/operator: [CLI guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/cli.md), [Python API](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/python_api.md), or
-  [Electron GUI](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/gui.md);
-- security reviewer: [threat model](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/threat_model.md),
-  [Capabilities](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/capabilities.md), and [data flow](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/data_flow.md);
-- extension author: [AgentImages](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/agent_images.md), [Skills](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/skills.md),
-  [Tools/JIT](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/tools_and_jit.md), or [Runtime Modules](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/modules.md);
-- contributor/maintainer: [development](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/development.md),
-  [benchmarking](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/benchmark.md), and [releasing](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/releasing.md).
+- user/operator: [CLI guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/cli.md), [Python API](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/python_api.md), or
+  [Electron GUI](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/gui.md);
+- security reviewer: [threat model](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/threat_model.md),
+  [Capabilities](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/capabilities.md), and [data flow](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/data_flow.md);
+- extension author: [AgentImages](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/agent_images.md), [Skills](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/skills.md),
+  [Tools/JIT](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/tools_and_jit.md), or [Runtime Modules](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/modules.md);
+- contributor/maintainer: [development](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/development.md),
+  [benchmarking](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/benchmark.md), and [releasing](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/releasing.md).
 
 ## Current System
 
@@ -224,70 +224,70 @@ product categories:
   distribution, not a public signed installer or update channel.
 
 Support and release claims are conditional on the exact version, platform,
-configuration, and required evidence. Consult the [support matrix](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/support_matrix.md)
+configuration, and required evidence. Consult the [support matrix](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/support_matrix.md)
 and maintained contract pages before generalizing from one demo or test run.
 
 ## Documentation
 
-The [documentation home](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/index.md) routes by audience and task and contains
+The [documentation home](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/index.md) routes by audience and task and contains
 the complete current-contract inventory. Direct entry points are grouped here.
 
 ### Use and operate Agent libOS
 
-- [CLI Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/cli.md) for workflows and security semantics;
-- [machine-generated exhaustive CLI reference](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/cli_reference.md) for the
+- [CLI Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/cli.md) for workflows and security semantics;
+- [machine-generated exhaustive CLI reference](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/cli_reference.md) for the
   checked-in parser, with the same installed version's `--help` as the live
   source;
-- [Python API](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/python_api.md) and [Electron GUI](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/gui.md);
-- [configuration guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/configuration.md) plus the
-  [machine-generated exhaustive field reference](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/configuration_reference.md);
-- [troubleshooting](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/troubleshooting.md), [storage/migration](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/storage.md),
-  and [support matrix](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/support_matrix.md);
-- [Durable Task Runs](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/durable_task_runs.md),
-  [Object Memory](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/object_memory.md), and [checkpoints](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/checkpoints.md).
+- [Python API](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/python_api.md) and [Electron GUI](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/gui.md);
+- [configuration guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/configuration.md) plus the
+  [machine-generated exhaustive field reference](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/configuration_reference.md);
+- [troubleshooting](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/troubleshooting.md), [storage/migration](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/storage.md),
+  and [support matrix](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/support_matrix.md);
+- [Durable Task Runs](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/durable_task_runs.md),
+  [Object Memory](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/object_memory.md), and [checkpoints](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/checkpoints.md).
 
 ### Understand the runtime and security boundary
 
-- [architecture](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/architecture.md), [runtime model](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/runtime_model.md),
-  [glossary and version map](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/glossary.md), and
-  [threat model](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/threat_model.md);
-- [Capabilities](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/capabilities.md),
-  [Task Authority Manifests](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/task_authority_manifest.md), and
-  [data flow and trusted Sinks](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/data_flow.md);
-- [semantic approval/data identification](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/semantic_shadow.md),
-  [Explainable Operations](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/explainable_operations.md), and
-  [Runtime events](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/events.md);
-- [evidence payload retention](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/evidence_payload_retention.md) and
-  [runtime invariants](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/invariants.md).
+- [architecture](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/architecture.md), [runtime model](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/runtime_model.md),
+  [glossary and version map](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/glossary.md), and
+  [threat model](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/threat_model.md);
+- [Capabilities](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/capabilities.md),
+  [Task Authority Manifests](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/task_authority_manifest.md), and
+  [data flow and trusted Sinks](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/data_flow.md);
+- [semantic approval/data identification](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/semantic_shadow.md),
+  [Explainable Operations](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/explainable_operations.md), and
+  [Runtime events](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/events.md);
+- [evidence payload retention](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/evidence_payload_retention.md) and
+  [runtime invariants](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/invariants.md).
 
 ### Extend and integrate
 
-- [AgentImage authoring](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/agent_images.md) and the specialized
-  [`mini-swe-agent` Image](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/mini_swe_agent_image.md);
-- [Skills](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/skills.md), [Tools and Deno/TypeScript JIT](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/tools_and_jit.md),
-  and [startup Runtime Modules](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/modules.md);
-- [Protected Operation SDK](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/protected_operation_sdk.md) and
-  [provider substrate](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/providers.md);
-- [typed Git](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/git.md), [JSON-RPC](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/jsonrpc.md), and
-  [MCP client](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/mcp.md);
-- [GUI API schema subset](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/gui_api_schema.json).
+- [AgentImage authoring](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/agent_images.md) and the specialized
+  [`mini-swe-agent` Image](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/mini_swe_agent_image.md);
+- [Skills](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/skills.md), [Tools and Deno/TypeScript JIT](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/tools_and_jit.md),
+  and [startup Runtime Modules](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/modules.md);
+- [Protected Operation SDK](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/protected_operation_sdk.md) and
+  [provider substrate](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/providers.md);
+- [typed Git](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/git.md), [JSON-RPC](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/jsonrpc.md), and
+  [MCP client](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/mcp.md);
+- [GUI API schema subset](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/gui_api_schema.json).
 
 ### Evaluate, contribute, and release
 
-- [benchmark contract](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/benchmark.md),
-  [runtime-safety schema](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/benchmarks/runtime_safety/schema.md),
-  [external-effect recovery](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/benchmarks/external_effect_recovery/README.md), and
-  [runtime-publication recovery](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/benchmarks/runtime_publication_recovery/README.md);
-- [practical workflows](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/benchmarks/practical_agent_workflows/README.md),
-  [built-in Tool Skill evaluation](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/benchmarks/builtin_tool_skills/README.md),
-  [long-horizon evaluation](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/benchmarks/long_horizon_agent/README.md), and
-  [AgentDojo](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/experiments/agentdojo/README.md);
-- [development guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/development.md), [release status](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/release_status.md),
-  and [maintainer release runbook](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/releasing.md);
-- [artifact anonymity](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/artifact_anonymity.md),
-  [research thesis](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/paper_thesis.md), [security policy](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/SECURITY.md),
-  [contribution guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/CONTRIBUTING.md), [changelog](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/CHANGELOG.md), and
-  [agent guidance](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/AGENTS.md).
+- [benchmark contract](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/benchmark.md),
+  [runtime-safety schema](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/benchmarks/runtime_safety/schema.md),
+  [external-effect recovery](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/benchmarks/external_effect_recovery/README.md), and
+  [runtime-publication recovery](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/benchmarks/runtime_publication_recovery/README.md);
+- [practical workflows](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/benchmarks/practical_agent_workflows/README.md),
+  [built-in Tool Skill evaluation](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/benchmarks/builtin_tool_skills/README.md),
+  [long-horizon evaluation](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/benchmarks/long_horizon_agent/README.md), and
+  [AgentDojo](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/experiments/agentdojo/README.md);
+- [development guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/development.md), [release status](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/release_status.md),
+  and [maintainer release runbook](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/releasing.md);
+- [artifact anonymity](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/artifact_anonymity.md),
+  [research thesis](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/paper_thesis.md), [security policy](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/SECURITY.md),
+  [contribution guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/CONTRIBUTING.md), [changelog](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/CHANGELOG.md), and
+  [agent guidance](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/AGENTS.md).
 
 Repository README links are checkout-relative so a branch, tag, fork, or source
 archive stays bound to its adjacent documentation. The release build generates
@@ -300,10 +300,10 @@ mutable-`main` contract links.
 These files are retained for traceability. Do not use them to infer current
 commands, interfaces, security guarantees, support, or release evidence:
 
-- [historical design archive notice](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/agent_libos_design_doc.md);
-- [historical paper roadmap notice](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/plan.md);
-- [retired commit-bound prelaunch review](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/prelaunch_hardening_report.md);
-- [commit-bound pre-implementation semantic research](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/semantic_permission_and_dataflow_research.md).
+- [historical design archive notice](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/agent_libos_design_doc.md);
+- [historical paper roadmap notice](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/plan.md);
+- [retired commit-bound prelaunch review](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/prelaunch_hardening_report.md);
+- [commit-bound pre-implementation semantic research](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/semantic_permission_and_dataflow_research.md).
 
 Each file states its baseline or retirement status and points back to maintained
 entry points. Git history, rather than a floating prose claim, is the source for
@@ -322,17 +322,30 @@ Tool Skills, and three console entry points: `agent-libos`,
 optional PTY module, and workspace Image/Skill packages remain checkout/source-
 archive assets rather than core-wheel contents.
 
+A published release version installs from a package index without a checkout:
+
+```bash
+pip install agent-libos
+# Optional integration extras mirror the source extras:
+pip install "agent-libos[mcp]"
+```
+
+A package install provides exactly the wheel contents and console entry points
+above. The repository assets listed above stay in the matching source checkout
+or source archive, and the package-index page's repository links point at that
+version's immutable `v<version>` tag rather than mutable `main`.
+
 Use the canonical page for every workflow beyond onboarding:
 
 | Task | Canonical page |
 | --- | --- |
-| Install, test, or change dependencies | [Development Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/development.md) |
-| Build, validate, publish, or recover artifacts | [Release Runbook](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/releasing.md) |
-| Migrate, back up, restore, or diagnose a store | [Storage](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/storage.md) |
-| Configure fields, profiles, modules, or providers | [Configuration Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/configuration.md) |
-| Operate the desktop or GUI server | [GUI Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/gui.md) |
-| Run or interpret evaluations | [Benchmark Contract](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/benchmark.md) |
-| Find a CLI workflow or every parser option | [CLI Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/cli.md) / [generated reference](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/cli_reference.md) |
+| Install, test, or change dependencies | [Development Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/development.md) |
+| Build, validate, publish, or recover artifacts | [Release Runbook](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/releasing.md) |
+| Migrate, back up, restore, or diagnose a store | [Storage](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/storage.md) |
+| Configure fields, profiles, modules, or providers | [Configuration Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/configuration.md) |
+| Operate the desktop or GUI server | [GUI Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/gui.md) |
+| Run or interpret evaluations | [Benchmark Contract](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/benchmark.md) |
+| Find a CLI workflow or every parser option | [CLI Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/cli.md) / [generated reference](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/cli_reference.md) |
 
 Those pages are the single sources for their commands, prerequisites, platform
 differences, safety gates, and expected evidence. Do not copy a release,
@@ -369,14 +382,14 @@ Object payloads do not gain that guarantee.
 
 Store administration is an offline operator workflow. Stop all writers, make
 the documented owner-only backup, preview the exact migration, verify its bound
-digest/state, and only then apply it. See [Storage](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/storage.md) and
-[Troubleshooting](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/troubleshooting.md).
+digest/state, and only then apply it. See [Storage](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/storage.md) and
+[Troubleshooting](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/troubleshooting.md).
 
 ### Upgrading stores that contain Tool Groups
 
 Legacy Tool Group metadata is a separate content migration to immutable built-in
 Tool Skills. Ordinary startup fails closed; use the dry-run-first procedure in
-[Tools and JIT](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/tools_and_jit.md#on-demand-tool-skills) and the offline
+[Tools and JIT](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/tools_and_jit.md#on-demand-tool-skills) and the offline
 storage guidance. Do not infer that a schema migration performs this conversion.
 
 ## Real LLM Configuration
@@ -403,9 +416,9 @@ provider's complete internal state, or permission to repeat an uncertain effect.
 Provider storage, prompt caching, local full-I/O retention, and response chaining
 are independent controls with different privacy and recovery consequences.
 
-Use [Configuration](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/configuration.md) for precedence and security semantics,
-the [generated field reference](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/configuration_reference.md) for exact fields
-and defaults, and [Development](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/development.md#real-llm-smoke) for an
+Use [Configuration](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/configuration.md) for precedence and security semantics,
+the [generated field reference](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/configuration_reference.md) for exact fields
+and defaults, and [Development](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/development.md#real-llm-smoke) for an
 explicit opt-in smoke path.
 
 ## Security Summary
@@ -445,13 +458,13 @@ explicit opt-in smoke path.
 - Remote access is Host-registered and configuration-bound. Models do not choose
   ad hoc URLs, credentials, subprocess transports, or trust roots.
 
-Read the [Threat Model](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/threat_model.md) for assets, adversaries, TCB,
-guarantees, and non-goals; [Runtime Invariants](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/invariants.md) maps current
+Read the [Threat Model](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/threat_model.md) for assets, adversaries, TCB,
+guarantees, and non-goals; [Runtime Invariants](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/invariants.md) maps current
 claims to tests.
 
 ## Contributing, Evaluation, and Releases
 
-Use the [Development Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/development.md) for environment setup, test
+Use the [Development Guide](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/development.md) for environment setup, test
 lanes, architecture checks, real-provider opt-ins, GUI validation, dependency
 changes, and documentation rules. Generated `agent_outputs/`, benchmark runs,
 credentials, local databases, and GUI build artifacts must not be committed.
@@ -459,13 +472,13 @@ credentials, local databases, and GUI build artifacts must not be committed.
 Evaluation output is source-bound evidence, not a standing performance or safety
 claim for another checkout. Preserve each suite's metadata, results, effects,
 metrics, model/provider identity, and declared evidence level together, and use
-the [Benchmark Contract](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/benchmark.md) to interpret denominators or failure.
+the [Benchmark Contract](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/benchmark.md) to interpret denominators or failure.
 
-The [Release Status](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/release_status.md) describes conditional scope and
+The [Release Status](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/release_status.md) describes conditional scope and
 required gates; it is not a pass receipt. Artifact building, signing, tagging,
 uploading, yanking, or changing external release state requires explicit Human
-authorization and the [Release Runbook](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/releasing.md).
+authorization and the [Release Runbook](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/releasing.md).
 
-See [CONTRIBUTING.md](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/CONTRIBUTING.md) for pull-request expectations and
-[SECURITY.md](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/SECURITY.md) for confidential vulnerability reporting. The project
-is licensed under the terms in [LICENSE](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/LICENSE).
+See [CONTRIBUTING.md](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/CONTRIBUTING.md) for pull-request expectations and
+[SECURITY.md](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/SECURITY.md) for confidential vulnerability reporting. The project
+is licensed under the terms in [LICENSE](https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/LICENSE).

--- a/agent_libos/__init__.py
+++ b/agent_libos/__init__.py
@@ -145,4 +145,4 @@ __all__ = [
     "WorkflowRunResult",
 ]
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"

--- a/agent_libos/api/cli.py
+++ b/agent_libos/api/cli.py
@@ -44,6 +44,7 @@ from agent_libos.models import (
 )
 from agent_libos.models.exceptions import HumanApprovalRequired, LibOSError, NotFound
 from agent_libos.models.exceptions import ValidationError as LibOSValidationError
+from agent_libos.models.task_runs import TaskRunStatus
 from agent_libos.modules import ModuleLoader
 from agent_libos.runtime.runtime import Runtime
 from agent_libos.storage import display_store_target
@@ -69,23 +70,8 @@ from agent_libos.api.semantic_public import (
 _RUNTIME_DEFAULTS = DEFAULT_CONFIG.runtime
 _WORKFLOW_HELP = "Run an Image-bound workflow tool directly without an LLM turn"
 _WORKFLOW_RUN_HELP = "Spawn a workflow process and call one tool from its complete process table"
-_TASK_RUN_STATUSES = frozenset(
-    {
-        "queued",
-        "running",
-        "waiting_human",
-        "waiting_process",
-        "waiting_message",
-        "waiting_tool",
-        "paused",
-        "cancelling",
-        "finalizing",
-        "needs_attention",
-        "succeeded",
-        "failed",
-        "cancelled",
-    }
-)
+_TASK_RUN_STATUS_VALUES = tuple(status.value for status in TaskRunStatus)
+_TASK_RUN_STATUSES = frozenset(_TASK_RUN_STATUS_VALUES)
 _TASK_RUN_RETENTIONS = ("purge_on_terminal", "permanent")
 _SEMANTIC_ASSESSMENT_PAGE_DEFAULT = 50
 _SEMANTIC_ASSESSMENT_PAGE_MAX = 100
@@ -219,17 +205,18 @@ def _add_payload_retention_parser_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "kind",
         choices=[item.value for item in PayloadRetentionKind],
+        help="Which bounded payload-retention page kind to preview or apply.",
     )
     parser.add_argument(
         "--apply",
         action="store_true",
         help="Apply the page; the default is a non-mutating dry run.",
     )
-    parser.add_argument("--limit", type=int)
-    parser.add_argument("--after-created-at")
-    parser.add_argument("--after-record-id")
-    parser.add_argument("--actor", default="host.retention")
-    parser.add_argument("--correlation-id")
+    parser.add_argument("--limit", type=int, help="Maximum rows in the page; bounded by the policy hard limit.")
+    parser.add_argument("--after-created-at", help="Opaque keyset cursor: created-at timestamp from the preceding page.")
+    parser.add_argument("--after-record-id", help="Opaque keyset cursor: record id from the preceding page.")
+    parser.add_argument("--actor", default="host.retention", help="Actor recorded for the retention operation; defaults to host.retention.")
+    parser.add_argument("--correlation-id", help="Correlation id recorded for the retention operation.")
 
 
 def _run_compact_command(
@@ -284,7 +271,7 @@ def _build_cli_parser() -> argparse.ArgumentParser:
         "--db",
         help=(
             "Runtime store target. 'user' uses the persistent per-user SQLite store; "
-            "paths use file SQLite; local/:memory:/sqlite:// use in-memory SQLite; "
+            "paths use file SQLite; 'local', ':memory:', and a bare 'sqlite://' use in-memory SQLite; a 'sqlite://' URI with a path selects that SQLite file; "
             "postgresql:// DSNs use PostgreSQL. "
             "If omitted, uses the selected config runtime store settings "
             f"(default '{_RUNTIME_DEFAULTS.local_store_target}' is persistent SQLite)."
@@ -671,6 +658,7 @@ def _add_store_parser_args(parser: argparse.ArgumentParser) -> None:
         type=int,
         choices=(5, 6, 7),
         required=True,
+        help="Target offline Runtime store schema version to plan or apply a migration to.",
     )
     mode = migrate.add_mutually_exclusive_group(required=True)
     mode.add_argument(
@@ -1572,7 +1560,11 @@ def _add_task_run_parser_args(parser: argparse.ArgumentParser) -> None:
         dest="statuses",
         action="append",
         default=[],
-        help="Filter status, comma-separated or repeated.",
+        help=(
+            "Filter status, comma-separated or repeated. Valid values: "
+            + ", ".join(_TASK_RUN_STATUS_VALUES)
+            + "."
+        ),
     )
     list_parser.add_argument("--cursor", help="Opaque keyset cursor from the preceding page.")
     list_parser.add_argument(
@@ -1913,7 +1905,10 @@ def _task_run_status_filters(values: list[str]) -> tuple[str, ...] | None:
     invalid = sorted(set(selected) - _TASK_RUN_STATUSES)
     if invalid:
         raise LibOSValidationError(
-            "invalid TaskRun status filter(s): " + ", ".join(invalid)
+            "invalid TaskRun status filter(s): "
+            + ", ".join(invalid)
+            + "; valid values: "
+            + ", ".join(_TASK_RUN_STATUS_VALUES)
         )
     return tuple(selected) or None
 
@@ -2708,8 +2703,8 @@ def _add_capabilities_parser_args(parser: argparse.ArgumentParser) -> None:
 
 def _add_capability_spec_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("resource")
-    parser.add_argument("--rights", nargs="+", required=True, choices=[right.value for right in CapabilityRight])
-    parser.add_argument("--effect", choices=[effect.value for effect in CapabilityEffect], default=CapabilityEffect.ALLOW.value)
+    parser.add_argument("--rights", nargs="+", required=True, choices=[right.value for right in CapabilityRight], help="One or more CapabilityRight values to grant or delegate.")
+    parser.add_argument("--effect", choices=[effect.value for effect in CapabilityEffect], default=CapabilityEffect.ALLOW.value, help="Effect of the granted/delegated right; defaults to allow.")
     parser.add_argument("--delegable", action="store_true")
     parser.add_argument("--revocable", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--uses-remaining", type=int)
@@ -3272,7 +3267,7 @@ def _add_mcp_task_subscription_parser_args(sub: Any) -> None:
         ),
     )
     subscription_listen.add_argument("server_id")
-    subscription_listen.add_argument("--filter", action="append", required=True)
+    subscription_listen.add_argument("--filter", action="append", required=True, help="Subscription filter token; repeatable, must be declared in the server manifest.")
     subscription_listen.add_argument(
         "--max-events",
         type=int,

--- a/agent_libos/substrate/local.py
+++ b/agent_libos/substrate/local.py
@@ -4990,7 +4990,7 @@ def _mcp_client_info(
         return mcp_types.Implementation(name="mcp", version="0.1.0")
     return mcp_types.Implementation(
         name="agent-libos",
-        version="1.5.1" if governed_modern else "1.4.2",
+        version="1.5.2" if governed_modern else "1.4.2",
     )
 
 

--- a/agent_libos_design_doc.md
+++ b/agent_libos_design_doc.md
@@ -3,7 +3,10 @@
 > **ARCHIVE — NOT A CURRENT CONTRACT.** This historical design archive is not the source of truth
 > for current behavior. Its early planned interfaces were
 > removed because they no longer matched the implementation and could be
-> mistaken for supported APIs.
+> mistaken for supported APIs. The retired archive content was last intact at
+> commit `1a267985c09ce9324747b4e14d8e38265a5f46f4` and was replaced by this
+> notice in commit `76ee42df4124bd491b95d88336335fd6a618c97f`; Git history is
+> the source for the full historical text.
 
 This notice is retained only so old links have an explicit migration path. Use
 the maintained references instead:

--- a/desktop/runtime-manifest.json
+++ b/desktop/runtime-manifest.json
@@ -3,7 +3,7 @@
   "distribution_channel": "internal-unsigned",
   "product": {
     "name": "Agent libOS",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "app_id": "io.agentlibos.desktop"
   },
   "toolchain": {

--- a/docs/agent_images.md
+++ b/docs/agent_images.md
@@ -13,10 +13,17 @@ resource authority. Read [Capabilities](capabilities.md),
 
 ## In this guide
 
-- [Create, validate, register, and boot a minimal package](#minimal-package)
-- [Choose manifest fields and prompt behavior](#manifest-fields)
-- [Control the tool table, authority declarations, and private workspace](#tool-table-and-model-projection)
-- [Package JIT tools and select an LLM profile](#packaged-jit-tools)
+- [Distinguish the Image kinds](#image-kinds)
+- [Create a minimal package](#minimal-package)
+- [Validate, register, and boot the package](#validate-before-registration)
+- [Review the allowed package layout](#package-layout)
+- [Choose manifest fields](#manifest-fields)
+- [Choose a prompt mode](#prompt-modes)
+- [Control the tool table and model projection](#tool-table-and-model-projection)
+- [Declare capabilities and required modules](#capability-and-module-declarations)
+- [Scope the private workspace seed](#private-workspace-seed)
+- [Package JIT tools](#packaged-jit-tools)
+- [Select an LLM profile and keep secrets out](#llm-profile-and-secrets)
 - [Create an Image from a checkpoint](#checkpoint-derived-images)
 - [Review the author checklist](#author-checklist)
 - Return to the [documentation home](index.md).
@@ -86,6 +93,9 @@ uv run agent-libos --db user \
 uv run agent-libos --db user \
   images inspect custom-review-agent:v0
 ```
+
+Like the Skills CLI, these commands accept `--actor-pid`; omitting it runs
+them in admin CLI mode with capability enforcement disabled.
 
 Registration rejects an existing image id unless the Host explicitly supplies
 `--replace`. Validation and registration read the package but do not invoke an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -594,12 +594,15 @@ endpoint manifest, then resolves URLs and env-backed headers from the registry
 only for an authorized call.
 
 The same split applies to MCP. `list_mcp_servers`, `inspect_mcp_server`,
-`list_mcp_tools`, and `call_mcp_tool` are stable generic wrappers over a
+`list_mcp_tools`, `call_mcp_tool`, and the Manifest v3 Resource readers
+`list_mcp_resources`/`read_mcp_resource` are stable generic wrappers over a
 registered MCP server registry. Remote MCP tools are not imported into the
 ToolBroker as first-class tools, and a model-projected `call_mcp_tool` entry still
 requires `mcp:<server>:<tool>` authority at primitive use. The call path also
 checks that derived tool resource before loading server metadata or input
 schemas, so missing authority cannot be used to enumerate provider manifests.
+The Resource wrappers stay behind the protected MCP facade and only surface
+model-visible Manifest v3 entries, never a remote URI or provider cursor.
 
 Manifest v1 remains on the initialize-based legacy MCP path. Manifest v2
 explicitly selects `legacy`, `auto`, or `2026-07-28` and requires the optional
@@ -873,6 +876,8 @@ agent_libos/
   human/           HumanObject query, approval, interrupt, and output primitives
   images/          built-in AgentImage definitions
   llm/             prompt, context, OpenAI-compatible client, executor, action parser
+  mcp/             MCP server manifests, OAuth manager, runtime bridge, supervisor,
+                   subscriptions, remote Tasks, and Elicitation continuations
   memory/          typed Object Memory and MemoryView implementation
   models/          dataclass and enum models split by runtime domain
   modules/         trusted startup Runtime Module loader, registry, and core module

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -15,13 +15,21 @@ without implicitly changing what resources they can affect.
 ## In this guide
 
 - [Capability record](#capability-record)
+- [Rights](#rights)
 - [Resource matching](#resource-matching)
 - [Authorization API](#authorization-api)
+- [Authority rules and profiles](#authority-rules-and-profiles)
 - [Issue, delegate, and revoke](#issue-delegate-revoke)
 - [Permission policy and Human approval](#permission-policy-and-human-approval)
-- [Data release as separate authority](#data-release-is-separate-authority)
+- [Data release is separate authority](#data-release-is-separate-authority)
 - [Tool, Skill, and JIT boundary](#tool-skill-and-jit-boundary)
+- [Process messages](#process-messages)
+- [CLI and syscalls](#cli-and-syscalls)
+- [JSON-RPC authority](#json-rpc-authority)
+- [MCP authority](#mcp-authority)
 - [Filesystem authority](#filesystem-authority)
+- [Shell authority](#shell-authority)
+- [Git authority](#git-authority)
 - Return to the [documentation home](index.md).
 
 ## Capability Record
@@ -655,9 +663,9 @@ protected external read: a process needs both `read` and `execute` on the exact
 or turn an unsupported server capability into a Runtime capability.
 
 For `stdio` MCP transports, actor-mode server registration, protocol discovery,
-live tool refresh, and tool calls additionally require both `process:spawn`
-`write` and `execute`
-on the exact `mcp_stdio:<sha256>` launch resource. The hash covers the canonical
+live tool refresh, and tool calls additionally require `write` on
+`process:spawn` and `execute` on the exact `mcp_stdio:<sha256>` launch
+resource. The hash covers the canonical
 command, argv, environment mapping, and cwd, so a grant for one launch surface
 cannot authorize another. Registration authorizes persisting that surface;
 refresh and calls are the operations that actually start a local child process.

--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -13,6 +13,7 @@ block, not a mechanism for rewinding the outside world.
 - [Restore](#restore)
 - [Commit to Image](#commit-to-image)
 - [Fork from checkpoint](#fork-from-checkpoint)
+- [Replay to Event](#replay-to-event)
 - [Limits](#limits)
 - Return to the [documentation home](index.md).
 
@@ -269,9 +270,17 @@ the five Skill bootstrap tools. Coding additionally binds restore/fork and is
 the only shipped Image whose complete table contains all six tools owned by
 `agent-libos-checkpoints`; activating that exact Skill projects the six together.
 Base and review omit restore/fork, so the immutable built-in Skill is hidden and
-cannot partially project their four static bindings. Toolmaker and
-context-compressor bind no checkpoint tools. Global tool registration alone is
-not model visibility, and every invocation still requires checkpoint authority.
+cannot partially project their four static bindings. The narrow direct
+`maintenance-agent:v0`, `research-agent:v0`, `analysis-agent:v0`, and
+`operator-agent:v0` images set no `tool_projection` and instead project their
+complete default tool tables at boot: research and analysis bind
+`create_checkpoint` only, maintenance binds it with `list_checkpoints`, and
+operator binds `create_checkpoint`, `list_checkpoints`, and
+`inspect_checkpoint`. Their checkpoint schemas are therefore initially
+model-visible because the Host selected the image's workflow domain in advance;
+none of the four binds diff, restore, or fork. Toolmaker and context-compressor
+bind no checkpoint tools. Global tool registration alone is not model
+visibility, and every invocation still requires checkpoint authority.
 
 Checkpoint inspect process rows expose the snapshot's canonical tagged
 `wait_state` and `outcome` mappings together with `state_generation`. The

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -294,8 +294,10 @@ uv run agent-libos --db user checkpoint --actor-pid <actor_pid> inspect <checkpo
 
 ## Exit Codes and Error Output
 
-Successful commands print one JSON document and exit with status 0. The status
-contract for everything else is stable:
+Successful structured commands print one JSON document and exit with status 0.
+Two command-interface exceptions also exit with status 0 but print plain text:
+`init` prints `initialized <target>`, and any `--help` invocation prints its
+argparse usage/help text. The status contract for everything else is stable:
 
 - Runtime domain errors (`LibOSError` subclasses, including validation and
   authority failures) are printed as the stable JSON envelope with
@@ -328,9 +330,11 @@ contract for everything else is stable:
 
 Scripts should treat status 1 as "read the printed error envelope or usage
 message", status 2 as "either a parser usage error or, from `explain`, an
-ambiguous id whose candidate list was printed", and status 0 as "parse the
-printed JSON". When collecting failure evidence, record the exact command, exit
-status, and the stable error `type`; see [Troubleshooting](troubleshooting.md).
+ambiguous id whose candidate list was printed", and status 0 as success. Parse
+the status-0 output as JSON for structured commands; handle the documented
+`init` acknowledgement and `--help` output as plain text. When collecting
+failure evidence, record the exact command, exit status, and the stable error
+`type`; see [Troubleshooting](troubleshooting.md).
 
 ## Persistent Runtime Basics
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,14 +11,24 @@ in sync with the parser.
 ## In this guide
 
 - [Configure the store, models, and startup modules](#configuration-file)
-- [Find a command and understand common output](#top-level-commands)
-- [Operate processes](#persistent-runtime-basics), [workflows](#workflow-run),
-  [TaskRuns](#durable-task-runs), and [ObjectTasks](#object-tasks)
+- [Find a command and understand common output](#top-level-commands) and
+  [exit codes and error envelopes](#exit-codes-and-error-output)
+- [Operate processes](#persistent-runtime-basics), including
+  [interactive run](#interactive-run), [messages](#process-messages),
+  [builtins](#process-builtins), [resources](#process-resources), and
+  [checkpoints](#checkpoint-commands)
+- [Run workflows](#workflow-run), [TaskRuns](#durable-task-runs),
+  [ObjectTasks](#object-tasks), and [Skills](#skill-commands)
 - [Author](#agentimage-packages) and [manage AgentImages](#image-commands)
 - [Inspect or administer Capabilities](#capability-commands)
+- [Inspect evidence](#explainable-operations), [LLM calls](#llm-calls),
+  [payload retention](#payload-retention), and
+  [semantic review data](#semantic-inspection-and-review-evidence)
+- [Bind launch authority manifests](#task-authority-manifest-at-launch)
 - [Use JSON-RPC](#json-rpc-commands), [MCP](#mcp-commands), and
   [startup Runtime Modules](#runtime-module-commands)
-- [Run evaluation and example scripts](#benchmark-scripts)
+- [Migrate legacy stores offline](#offline-store-migration)
+- Run [evaluation](#benchmark-scripts) and [example scripts](#example-scripts)
 - Return to the [documentation home](index.md).
 
 The package installs the `agent-libos` command.
@@ -33,8 +43,10 @@ one-time migration command for legacy stores. It defaults to a rolled-back dry
 run and is not a normal Runtime control surface; see [Tool Skills](tools_and_jit.md).
 
 Use `--db` to select a runtime store. The reserved `user` target resolves to
-the persistent `~/.agent-libos/runtime/agent-libos.sqlite`; it is also the
-default when `--db` is omitted. The `local` and `:memory:` sentinels are
+the persistent `~/.agent-libos/runtime/agent-libos.sqlite`; under the default
+configuration it is also the target used when `--db` is omitted, but a config
+overlay can select another target or a PostgreSQL DSN (see
+[Configuration File](#configuration-file)). The `local` and `:memory:` sentinels are
 in-memory SQLite. Any other filesystem path creates or opens a persistent
 SQLite database, provided it is outside the effective model-visible workspace.
 A `postgresql://` or `postgres://` DSN opens a PostgreSQL runtime store.
@@ -58,7 +70,8 @@ to no scheduler run and to dropping external capabilities, and a bare
 Runtime domain errors are printed as a stable JSON object with
 `schema_version`, `error.type`, and `error.message`, and exit with status 1;
 the installed command does not expose a Python traceback for ordinary user
-errors.
+errors. See [Exit codes and error output](#exit-codes-and-error-output) for the
+complete status contract.
 
 ## Configuration File
 
@@ -80,7 +93,8 @@ JSON-type boundary. In particular, an ordinary integer or float config field
 may coerce YAML `true`/`false` to `1`/`0`; do not use booleans as numeric
 configuration values. Fields declared with `StrictInt` or `StrictFloat` reject
 that coercion, and numeric bounds still receive explicit post-construction
-validation. See [Configuration](configuration.md#loading-and-precedence) for
+validation. See
+[Configuration](configuration.md#loading-and-precedence) for
 the authoritative strict-field groups. For the exhaustive path, input-type,
 default, and unit inventory, use the
 [generated configuration field reference](configuration_reference.md).
@@ -278,6 +292,46 @@ uv run agent-libos --db user capabilities --actor-pid <actor_pid> grant <subject
 uv run agent-libos --db user checkpoint --actor-pid <actor_pid> inspect <checkpoint_id>
 ```
 
+## Exit Codes and Error Output
+
+Successful commands print one JSON document and exit with status 0. The status
+contract for everything else is stable:
+
+- Runtime domain errors (`LibOSError` subclasses, including validation and
+  authority failures) are printed as the stable JSON envelope with
+  `schema_version`, `error.type`, and `error.message`, and exit with status 1.
+  A not-found evidence id in `explain` prints the same envelope shape with
+  `error.type: NotFound` and also exits with status 1.
+- Argument-parser usage failures (a missing required argument or an invalid
+  subcommand choice) follow the argparse convention: the usage message goes to
+  stderr and the command exits with status 2.
+- Usage failures detected by the CLI after parsing, such as a malformed
+  `--args-json`/`--arguments-json` object or mutually exclusive options used
+  together, print their plain message without the JSON envelope and exit with
+  status 1.
+- `workflow run` prints the tool result JSON even when it is `ok: false`, then
+  exits with status 1.
+- `mcp` operations print the structured result exactly once; a returned
+  `ok: false` result exits with status 1 and the provider call is not retried.
+- `explain` prints the explicit causal-root candidates for an ambiguous
+  evidence id and exits with status 2, sharing that status with parser usage
+  failures. Its stdout still carries the JSON candidate list, so automation
+  distinguishes the two cases by the printed output.
+- `jsonrpc call` deliberately exits 0 even when the delivered result carries
+  `status: jsonrpc_error`, `http_error`, or `transport_error`: the JSON-RPC
+  response or transport-failure envelope was delivered and printed as the
+  command's output. Callers must inspect the printed `status` and `ok` fields
+  rather than the shell status.
+- `task-run`, `object-task`, and the other structured management commands exit
+  0 for successful structured responses, including waiting states and
+  `needs_attention`; only a runtime domain error moves them to status 1.
+
+Scripts should treat status 1 as "read the printed error envelope or usage
+message", status 2 as "either a parser usage error or, from `explain`, an
+ambiguous id whose candidate list was printed", and status 0 as "parse the
+printed JSON". When collecting failure evidence, record the exact command, exit
+status, and the stable error `type`; see [Troubleshooting](troubleshooting.md).
+
 ## Persistent Runtime Basics
 
 The current Runtime opens only store schema v7. A canonical schema-v6 database
@@ -336,11 +390,11 @@ resource when that setting changes.
 
 `run` uses the high-level runtime scheduler, so human terminal messages are
 processed as part of runtime execution. Without `--max-quanta`, it uses
-`runtime.run_until_idle_max_quanta`; the checked-in config may bound that value.
-Only a configured `null` value means run until the Runtime becomes idle without
-a quantum limit. Pass `--max-quanta <n>` to set an explicit bound on the total
-number of LLM/tool quanta across all runnable processes. Interactive run,
-`exec --run`, and `message --run` use the same default.
+`runtime.run_until_idle_max_quanta`; the checked-in config leaves that value
+`null`, so a bare run executes until the Runtime becomes idle without a quantum
+limit. Pass `--max-quanta <n>` to set an explicit bound on the total number of
+LLM/tool quanta across all runnable processes and to bound provider token
+spend. Interactive run, `exec --run`, and `message --run` use the same default.
 
 `cd <pid> <path>` requires filesystem `read` authority for the selected
 directory. Explicit working directories for child processes and PTY creation
@@ -654,7 +708,7 @@ Useful leaf options are:
 | Command | Durable controls |
 | --- | --- |
 | `start` | Exactly one of `--goal`/`--goal-json`, required `--title`, optional Image/launch/authority/deadline/retention fields, stable `--client-request-id`, and explicit `--run [--max-quanta N] [--run-command-id ID]`; launch JSON accepts only `capabilities`, `resource_budget`, `working_directory`, and `llm_profile_id` and must not contain credentials |
-| `list` | Repeated or comma-separated `--status`, opaque `--cursor`, and bounded `--limit` |
+| `list` | Repeated or comma-separated `--status` over the closed status set (`queued`, `running`, `waiting_human`, `waiting_process`, `waiting_message`, `waiting_tool`, `paused`, `cancelling`, `finalizing`, `needs_attention`, `succeeded`, `failed`, `cancelled`), opaque `--cursor`, and bounded `--limit`; an unknown status value is rejected with the valid list |
 | `wait` | Optional finite `--timeout`; it has no run command id because it never mutates or dispatches |
 | `recovery-options` | Read-only, server-derived recovery choices for the Run; use the returned opaque `option_id` with `recover` |
 | `pause` / `resume` | Required `--expected-revision`; optional stable `--command-id` is generated for a one-shot invocation when omitted |
@@ -1004,8 +1058,14 @@ replacement goal.
 `cd` checks `read` on the exact canonical directory resource; the first grant
 above covers the checked-in `agent_libos/` directory. An exec that changes the
 image checks `read` on `image:<target_image_id>`, which is why the example grants
-the review image explicitly. Exec preserves Object Memory by default, drops
-external capabilities by default, and does not run unless `--run` is present.
+the review image explicitly: that target names an already-registered image id.
+When the exec target is an image package directory instead, the CLI loads and
+registers it as Host admin (no image capability is required for the load) and
+automatically grants the target pid `read` on the resulting `image:<id>`
+resource, recording `cli` as the issuer; the explicit `capabilities grant` is
+needed only for already-registered image ids. Exec preserves Object Memory by
+default, drops external capabilities by default, and does not run unless `--run`
+is present.
 Here `--no-preserve-memory` replaces any stale prior view with the live goal,
 while `--preserve-capabilities` keeps the Host-issued directory, image, and
 Human grants needed by the new process. Those grants satisfy and narrow the
@@ -1024,8 +1084,10 @@ Useful exec options:
   `runtime.run_until_idle_max_quanta`, whose `null` value means unbounded until
   idle.
 
-Exec never grants target-image `required_capabilities` automatically. If the
-target is an image package, its `workspace/` seed is materialized into a private
+Exec never grants a target image's declared `required_capabilities`
+automatically; the automatic grant described above covers only the image `read`
+authority needed to exec into a freshly loaded package. If the target is an
+image package, its `workspace/` seed is materialized into a private
 per-process directory under `image.materialized_workspace_root` (by default
 `agent_outputs/image_workspaces/`). For any target image, `required_modules` are
 checked before boot; the runtime must already have loaded each declared

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -853,7 +853,7 @@ usage: agent-libos exec [-h] image goal --pid PID [--llm-profile LLM_PROFILE]
 | `--llm-profile LLM_PROFILE` | no | `None` | Optional host-selected LLM profile id for the existing process. |
 | `--replace-image` | no | `replace_image=False` | Allow an image package to replace an existing image id. |
 | `--args-json ARGS_JSON` | no | `'{}'` | JSON object recorded as structured exec args. |
-| `--preserve-memory, --no-preserve-memory` | no | `True` | Keep the current MemoryView across exec. Use --no-preserve-memory to replace it with the new goal only. |
+| `--preserve-memory, --no-preserve-memory` | no | `preserve_memory=True` | Keep the current MemoryView across exec. Use --no-preserve-memory to replace it with the new goal only. |
 | `--preserve-capabilities` | no | `preserve_capabilities=False` | Keep existing external capabilities. Exec never grants target image required_capabilities automatically. |
 | `--run` | no | `run=False` | Run the scheduler after exec. |
 | `--no-run` | no | `run=False` | Only apply exec; do not run the scheduler. |
@@ -1299,7 +1299,7 @@ usage: agent-libos capabilities grant [-h] subject resource
 | `--rights {read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} [{read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} ...]` | yes | `None` | One or more CapabilityRight values to grant or delegate. |
 | `--effect {allow,deny,ask}` | no | `'allow'` | Effect of the granted/delegated right; defaults to allow. |
 | `--delegable` | no | `delegable=False` | — |
-| `--revocable, --no-revocable` | no | `True` | — |
+| `--revocable, --no-revocable` | no | `revocable=True` | — |
 | `--uses-remaining USES_REMAINING` | no | `None` | — |
 | `--expires-at EXPIRES_AT` | no | `None` | — |
 | `--constraints-json CONSTRAINTS_JSON` | no | `'{}'` | Capability constraint JSON object. |
@@ -1329,7 +1329,7 @@ usage: agent-libos capabilities delegate [-h] parent child resource
 | `--rights {read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} [{read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} ...]` | yes | `None` | One or more CapabilityRight values to grant or delegate. |
 | `--effect {allow,deny,ask}` | no | `'allow'` | Effect of the granted/delegated right; defaults to allow. |
 | `--delegable` | no | `delegable=False` | — |
-| `--revocable, --no-revocable` | no | `True` | — |
+| `--revocable, --no-revocable` | no | `revocable=True` | — |
 | `--uses-remaining USES_REMAINING` | no | `None` | — |
 | `--expires-at EXPIRES_AT` | no | `None` | — |
 | `--constraints-json CONSTRAINTS_JSON` | no | `'{}'` | Capability constraint JSON object. |

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -7,9 +7,13 @@ This is the exhaustive command and argument inventory for the checked-in
 use the [CLI Guide](cli.md). Defaults shown here are parser defaults; effective
 Runtime settings may additionally come from `DEFAULT_CONFIG`, `config.yaml`, or
 an explicit `--config` overlay as described in the
-[Configuration Guide](configuration.md). Usage wrapping and metavars are
-normalized across supported Python versions; every accepted option alias is
-listed in the Arguments tables.
+[Configuration Guide](configuration.md). For flags that store a constant
+(including inverse-named flags such as `--optional` and `--flag/--no-flag`
+pairs sharing one destination), the Default column shows `name=value`: the
+parser destination the flag writes and that destination's effective value when
+the flag is absent; passing the flag stores the flag's constant instead.
+Usage wrapping and metavars are normalized across supported Python versions;
+every accepted option alias is listed in the Arguments tables.
 
 [documentation home](index.md)
 
@@ -62,7 +66,7 @@ usage: agent-libos [-h] [--config CONFIG] [--db DB] [--module-manifest MODULE_MA
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
 | `--config CONFIG` | no | `None` | YAML config overlay. Defaults to the project-root config.yaml when present. |
-| `--db DB` | no | `None` | Runtime store target. 'user' uses the persistent per-user SQLite store; paths use file SQLite; local/:memory:/sqlite:// use in-memory SQLite; postgresql:// DSNs use PostgreSQL. If omitted, uses the selected config runtime store settings (default 'user' is persistent SQLite). |
+| `--db DB` | no | `None` | Runtime store target. 'user' uses the persistent per-user SQLite store; paths use file SQLite; 'local', ':memory:', and a bare 'sqlite://' use in-memory SQLite; a 'sqlite://' URI with a path selects that SQLite file; postgresql:// DSNs use PostgreSQL. If omitted, uses the selected config runtime store settings (default 'user' is persistent SQLite). |
 | `--module-manifest MODULE_MANIFEST` | no | `[]` | Trusted startup module manifest to load before the runtime is used. May be passed multiple times. |
 | `--trusted-module TRUSTED_MODULE` | no | `[]` | Trusted startup module entry in the form '<module_id>:<manifest_sha256>:<source_sha256>'. Use the trust_key from `modules verify`. |
 | `--trusted-module-sha256 TRUSTED_MODULE_SHA256` | no | `[]` | Trusted startup module digest pair in the form '<manifest_sha256>:<source_sha256>', regardless of module id. Intended for local development only. |
@@ -338,13 +342,13 @@ usage: agent-libos payload-retention [-h] {llm_call,external_effect} [--apply]
 | Syntax | Required | Default | Description |
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
-| `{llm_call,external_effect}` | yes | `None` | — |
-| `--apply` | no | `False` | Apply the page; the default is a non-mutating dry run. |
-| `--limit LIMIT` | no | `None` | — |
-| `--after-created-at AFTER_CREATED_AT` | no | `None` | — |
-| `--after-record-id AFTER_RECORD_ID` | no | `None` | — |
-| `--actor ACTOR` | no | `'host.retention'` | — |
-| `--correlation-id CORRELATION_ID` | no | `None` | — |
+| `{llm_call,external_effect}` | yes | `None` | Which bounded payload-retention page kind to preview or apply. |
+| `--apply` | no | `apply=False` | Apply the page; the default is a non-mutating dry run. |
+| `--limit LIMIT` | no | `None` | Maximum rows in the page; bounded by the policy hard limit. |
+| `--after-created-at AFTER_CREATED_AT` | no | `None` | Opaque keyset cursor: created-at timestamp from the preceding page. |
+| `--after-record-id AFTER_RECORD_ID` | no | `None` | Opaque keyset cursor: record id from the preceding page. |
+| `--actor ACTOR` | no | `'host.retention'` | Actor recorded for the retention operation; defaults to host.retention. |
+| `--correlation-id CORRELATION_ID` | no | `None` | Correlation id recorded for the retention operation. |
 
 ## `agent-libos processes`
 
@@ -474,12 +478,12 @@ usage: agent-libos object-task start [-h] --pid PID
 | `--notify-pid NOTIFY_PID` | no | `None` | Process to notify; defaults to --pid. |
 | `--notify-kind {normal,interrupt}` | no | `'normal'` | — |
 | `--notify-channel NOTIFY_CHANNEL` | no | `None` | Process-message channel; defaults to object-task. |
-| `--watch-owner` | no | `False` | Notify the runner process when the owner object is updated or linked. |
+| `--watch-owner` | no | `watch_owner=False` | Notify the runner process when the owner object is updated or linked. |
 | `--watch-events WATCH_EVENTS` | no | `[]` | Owner events to watch, comma-separated or repeated. Defaults to updated,linked when --watch-owner is set. |
 | `--watch-channel WATCH_CHANNEL` | no | `None` | Runner message channel for owner-watch notices; defaults to object-task-owner. |
 | `--watch-kind {normal,interrupt}` | no | `'normal'` | — |
-| `--grant-result-to-notify` | no | `False` | Try to grant result read authority to notify pid; requires object grant authority. |
-| `--wait` | yes | `False` | Required by the one-shot CLI; wait until the task reaches a terminal or explicit waiting state before printing. |
+| `--grant-result-to-notify` | no | `grant_result_to_notify=False` | Try to grant result read authority to notify pid; requires object grant authority. |
+| `--wait` | yes | `wait=False` | Required by the one-shot CLI; wait until the task reaches a terminal or explicit waiting state before printing. |
 | `--timeout TIMEOUT` | no | `None` | Optional wait timeout in seconds. |
 
 ## `agent-libos object-task get`
@@ -510,7 +514,7 @@ usage: agent-libos object-task list [-h] [--pid PID] [--owner-oid OWNER_OID] [--
 | `-h, --help` | no | — | show this help message and exit |
 | `--pid PID` | no | `None` | Actor process id for visibility checks. |
 | `--owner-oid OWNER_OID` | no | `None` | Filter by owner object id. |
-| `--active` | no | `False` | Only include non-terminal tasks. |
+| `--active` | no | `active=False` | Only include non-terminal tasks. |
 | `--limit LIMIT` | no | `None` | — |
 
 ## `agent-libos object-task cancel`
@@ -559,7 +563,7 @@ usage: agent-libos object-task watch-owner [-h] task_id --pid PID [--disable]
 | `-h, --help` | no | — | show this help message and exit |
 | `task_id` | yes | `None` | — |
 | `--pid PID` | yes | `None` | Actor process id. |
-| `--disable` | no | `False` | Disable owner-change notices. |
+| `--disable` | no | `disable=False` | Disable owner-change notices. |
 | `--watch-events WATCH_EVENTS` | no | `[]` | Owner events to watch, comma-separated or repeated. |
 | `--watch-channel WATCH_CHANNEL` | no | `None` | Runner message channel for owner-watch notices. |
 | `--watch-kind {normal,interrupt}` | no | `None` | — |
@@ -621,7 +625,7 @@ usage: agent-libos task-run start [-h] (--goal GOAL | --goal-json GOAL_JSON)
 | `--deadline-at DEADLINE_AT` | no | `None` | Optional absolute wall-clock deadline timestamp. |
 | `--retention {purge_on_terminal,permanent}` | no | `'purge_on_terminal'` | Durable payload retention policy; permanent is Host/admin only. |
 | `--client-request-id CLIENT_REQUEST_ID` | no | `None` | Stable client request id for create idempotency; omitted generates one. |
-| `--run` | no | `False` | After creation, run until the run blocks, finishes, or exhausts --max-quanta. |
+| `--run` | no | `run=False` | After creation, run until the run blocks, finishes, or exhausts --max-quanta. |
 | `--run-command-id RUN_COMMAND_ID` | no | `None` | Stable command id for the separate --run mutation. |
 | `--max-quanta MAX_QUANTA` | no | `None` | Optional scheduler quantum budget used only with --run. |
 
@@ -650,7 +654,7 @@ usage: agent-libos task-run list [-h] [--status STATUSES] [--cursor CURSOR]
 | Syntax | Required | Default | Description |
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
-| `--status STATUSES` | no | `[]` | Filter status, comma-separated or repeated. |
+| `--status STATUSES` | no | `[]` | Filter status, comma-separated or repeated. Valid values: queued, running, waiting_human, waiting_process, waiting_message, waiting_tool, paused, cancelling, finalizing, needs_attention, succeeded, failed, cancelled. |
 | `--cursor CURSOR` | no | `None` | Opaque keyset cursor from the preceding page. |
 | `--limit LIMIT` | no | `100` | Page size from 1 through 500. |
 
@@ -728,7 +732,7 @@ usage: agent-libos task-run cancel [-h] run_id [--reason REASON] --confirm
 | `-h, --help` | no | — | show this help message and exit |
 | `run_id` | yes | `None` | — |
 | `--reason REASON` | no | `None` | — |
-| `--confirm` | yes | `False` | Confirm durable cancellation and descendant termination. |
+| `--confirm` | yes | `confirm=False` | Confirm durable cancellation and descendant termination. |
 | `--expected-revision EXPECTED_REVISION` | yes | `None` | Revision last observed by this client; stale revisions are rejected. |
 | `--command-id COMMAND_ID` | no | `None` | Stable idempotency id; omitted generates one for this invocation. |
 
@@ -750,8 +754,8 @@ usage: agent-libos task-run follow-up [-h] run_id [content] [--content CONTENT_O
 | `[content]` | no | `None` | Follow-up requirement text; alternatively use --content or --content-json. |
 | `--content CONTENT_OPTION` | no | `None` | Follow-up requirement text. |
 | `--content-json CONTENT_JSON` | no | `None` | Follow-up requirement as strict JSON. |
-| `--interrupt` | no | `False` | Also interrupt the active root process after durably recording the requirement. |
-| `--optional` | no | `True` | Record the follow-up without making it a required success condition. |
+| `--interrupt` | no | `interrupt=False` | Also interrupt the active root process after durably recording the requirement. |
+| `--optional` | no | `required=True` | Record the follow-up without making it a required success condition. |
 | `--expected-revision EXPECTED_REVISION` | yes | `None` | Revision last observed by this client; stale revisions are rejected. |
 | `--command-id COMMAND_ID` | no | `None` | Stable idempotency id; omitted generates one for this invocation. |
 
@@ -773,7 +777,7 @@ usage: agent-libos task-run recover [-h] run_id [option] [--option OPTION_FLAG]
 | `[option]` | no | `None` | Exact recovery option returned by the server; alternatively use --option. |
 | `--option OPTION_FLAG` | no | `None` | Exact server-provided recovery option. |
 | `--receipt-json, --evidence-json RECEIPT_JSON` | no | `None` | Optional authoritative receipt as a strict JSON object. |
-| `--confirm` | yes | `False` | Confirm the selected evidence-backed recovery action. |
+| `--confirm` | yes | `confirm=False` | Confirm the selected evidence-backed recovery action. |
 | `--expected-revision EXPECTED_REVISION` | yes | `None` | Revision last observed by this client; stale revisions are rejected. |
 | `--command-id COMMAND_ID` | no | `None` | Stable idempotency id; omitted generates one for this invocation. |
 
@@ -847,12 +851,12 @@ usage: agent-libos exec [-h] image goal --pid PID [--llm-profile LLM_PROFILE]
 | `goal` | yes | `None` | Replacement process goal. |
 | `--pid PID` | yes | `None` | Process id to exec. |
 | `--llm-profile LLM_PROFILE` | no | `None` | Optional host-selected LLM profile id for the existing process. |
-| `--replace-image` | no | `False` | Allow an image package to replace an existing image id. |
+| `--replace-image` | no | `replace_image=False` | Allow an image package to replace an existing image id. |
 | `--args-json ARGS_JSON` | no | `'{}'` | JSON object recorded as structured exec args. |
 | `--preserve-memory, --no-preserve-memory` | no | `True` | Keep the current MemoryView across exec. Use --no-preserve-memory to replace it with the new goal only. |
-| `--preserve-capabilities` | no | `False` | Keep existing external capabilities. Exec never grants target image required_capabilities automatically. |
-| `--run` | no | `False` | Run the scheduler after exec. |
-| `--no-run` | no | `True` | Only apply exec; do not run the scheduler. |
+| `--preserve-capabilities` | no | `preserve_capabilities=False` | Keep existing external capabilities. Exec never grants target image required_capabilities automatically. |
+| `--run` | no | `run=False` | Run the scheduler after exec. |
+| `--no-run` | no | `run=False` | Only apply exec; do not run the scheduler. |
 | `--max-quanta MAX_QUANTA` | no | `None` | Optional quantum budget when --run is set; omitted uses runtime.run_until_idle_max_quanta (which may be unbounded). |
 
 ## `agent-libos exit`
@@ -871,7 +875,7 @@ usage: agent-libos exit [-h] pid [--message MESSAGE] [--payload PAYLOAD]
 | `--message MESSAGE` | no | `None` | Optional final message stored in a label-bearing process-result Object. |
 | `--payload PAYLOAD` | no | `None` | Optional JSON final-result payload. Non-JSON text is wrapped as content. |
 | `--result-oid RESULT_OID` | no | `None` | Existing object id to use as process result. |
-| `--failed` | no | `False` | Mark the process as failed instead of exited. |
+| `--failed` | no | `failed=False` | Mark the process as failed instead of exited. |
 
 ## `agent-libos llm-once`
 
@@ -899,7 +903,7 @@ usage: agent-libos run [-h] [--max-quanta MAX_QUANTA] [--interactive] [--pid PID
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
 | `--max-quanta MAX_QUANTA` | no | `None` | Optional quantum budget; omitted uses runtime.run_until_idle_max_quanta (which may be unbounded). |
-| `--interactive` | no | `False` | Read human input while running and post it as process messages. |
+| `--interactive` | no | `interactive=False` | Read human input while running and post it as process messages. |
 | `--pid PID` | no | `None` | Default target process for interactive human messages. |
 | `--human HUMAN` | no | `None` | Human actor name for interactive messages. |
 | `--message-channel MESSAGE_CHANNEL` | no | `'human'` | Process-message channel for interactive human input. |
@@ -922,14 +926,14 @@ usage: agent-libos message [-h] pid body [--kind {normal,interrupt}] [--interrup
 | `pid` | yes | `None` | Target process id. |
 | `body` | yes | `None` | Message body. Quote it to include spaces. |
 | `--kind {normal,interrupt}` | no | `'normal'` | — |
-| `--interrupt` | no | `False` | Shortcut for --kind interrupt. |
+| `--interrupt` | no | `interrupt=False` | Shortcut for --kind interrupt. |
 | `--human HUMAN` | no | `None` | Human actor name. |
 | `--channel CHANNEL` | no | `'human'` | Process-message channel. |
 | `--subject SUBJECT` | no | `None` | Short message subject. |
 | `--correlation-id CORRELATION_ID` | no | `None` | Optional conversation/request correlation id. |
 | `--reply-to REPLY_TO` | no | `None` | Optional message id this message replies to. |
 | `--payload-json PAYLOAD_JSON` | no | `'{}'` | Structured JSON object to include in the message payload. |
-| `--run` | no | `False` | Run the scheduler after posting the message. |
+| `--run` | no | `run=False` | Run the scheduler after posting the message. |
 | `--max-quanta MAX_QUANTA` | no | `None` | Optional quantum budget when --run is set; omitted uses runtime.run_until_idle_max_quanta (which may be unbounded). |
 
 ## `agent-libos interrupt`
@@ -954,7 +958,7 @@ usage: agent-libos interrupt [-h] pid body [--human HUMAN] [--channel CHANNEL]
 | `--correlation-id CORRELATION_ID` | no | `None` | Optional conversation/request correlation id. |
 | `--reply-to REPLY_TO` | no | `None` | Optional message id this message replies to. |
 | `--payload-json PAYLOAD_JSON` | no | `'{}'` | Structured JSON object to include in the message payload. |
-| `--run` | no | `False` | Run the scheduler after posting the message. |
+| `--run` | no | `run=False` | Run the scheduler after posting the message. |
 | `--max-quanta MAX_QUANTA` | no | `None` | Optional quantum budget when --run is set; omitted uses runtime.run_until_idle_max_quanta (which may be unbounded). |
 
 ## `agent-libos checkpoint`
@@ -1159,7 +1163,7 @@ usage: agent-libos skills register [-h] path [--replace]
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
 | `path` | yes | `None` | — |
-| `--replace` | no | `False` | — |
+| `--replace` | no | `replace=False` | — |
 | `--source-type {workspace,global,runtime}` | no | `None` | — |
 
 ## `agent-libos skills activate`
@@ -1256,7 +1260,7 @@ usage: agent-libos capabilities list [-h] [--subject SUBJECT] [--include-inactiv
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
 | `--subject SUBJECT` | no | `None` | Subject pid/name to list. Defaults to actor pid in process mode; all in admin mode. |
-| `--include-inactive` | no | `False` | — |
+| `--include-inactive` | no | `include_inactive=False` | — |
 | `--limit LIMIT` | no | `None` | — |
 
 ## `agent-libos capabilities inspect`
@@ -1292,9 +1296,9 @@ usage: agent-libos capabilities grant [-h] subject resource
 | `-h, --help` | no | — | show this help message and exit |
 | `subject` | yes | `None` | — |
 | `resource` | yes | `None` | — |
-| `--rights {read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} [{read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} ...]` | yes | `None` | — |
-| `--effect {allow,deny,ask}` | no | `'allow'` | — |
-| `--delegable` | no | `False` | — |
+| `--rights {read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} [{read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} ...]` | yes | `None` | One or more CapabilityRight values to grant or delegate. |
+| `--effect {allow,deny,ask}` | no | `'allow'` | Effect of the granted/delegated right; defaults to allow. |
+| `--delegable` | no | `delegable=False` | — |
 | `--revocable, --no-revocable` | no | `True` | — |
 | `--uses-remaining USES_REMAINING` | no | `None` | — |
 | `--expires-at EXPIRES_AT` | no | `None` | — |
@@ -1322,9 +1326,9 @@ usage: agent-libos capabilities delegate [-h] parent child resource
 | `parent` | yes | `None` | — |
 | `child` | yes | `None` | — |
 | `resource` | yes | `None` | — |
-| `--rights {read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} [{read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} ...]` | yes | `None` | — |
-| `--effect {allow,deny,ask}` | no | `'allow'` | — |
-| `--delegable` | no | `False` | — |
+| `--rights {read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} [{read,write,execute,link,diff,materialize,delete,grant,revoke,approve,admin} ...]` | yes | `None` | One or more CapabilityRight values to grant or delegate. |
+| `--effect {allow,deny,ask}` | no | `'allow'` | Effect of the granted/delegated right; defaults to allow. |
+| `--delegable` | no | `delegable=False` | — |
 | `--revocable, --no-revocable` | no | `True` | — |
 | `--uses-remaining USES_REMAINING` | no | `None` | — |
 | `--expires-at EXPIRES_AT` | no | `None` | — |
@@ -1437,7 +1441,7 @@ usage: agent-libos images register [-h] path [--replace]
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
 | `path` | yes | `None` | — |
-| `--replace` | no | `False` | — |
+| `--replace` | no | `replace=False` | — |
 
 ## `agent-libos images commit`
 
@@ -1456,7 +1460,7 @@ usage: agent-libos images commit [-h] checkpoint_id image_id --name NAME
 | `image_id` | yes | `None` | — |
 | `--name NAME` | yes | `None` | — |
 | `--version VERSION` | no | `'v0'` | — |
-| `--replace` | no | `False` | — |
+| `--replace` | no | `replace=False` | — |
 | `--metadata-json METADATA_JSON` | no | `'{}'` | Optional image metadata JSON object. |
 
 ## `agent-libos jsonrpc`
@@ -1495,7 +1499,7 @@ usage: agent-libos jsonrpc register [-h] path [--replace]
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
 | `path` | yes | `None` | — |
-| `--replace` | no | `False` | — |
+| `--replace` | no | `replace=False` | — |
 
 ## `agent-libos jsonrpc list`
 
@@ -1608,7 +1612,7 @@ usage: agent-libos mcp register [-h] path [--replace]
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
 | `path` | yes | `None` | — |
-| `--replace` | no | `False` | — |
+| `--replace` | no | `replace=False` | — |
 
 ## `agent-libos mcp list`
 
@@ -1662,7 +1666,7 @@ usage: agent-libos mcp tools [-h] server_id [--refresh]
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
 | `server_id` | yes | `None` | — |
-| `--refresh` | no | `False` | Query the live MCP server for current tool metadata. |
+| `--refresh` | no | `refresh=False` | Query the live MCP server for current tool metadata. |
 
 ## `agent-libos mcp call`
 
@@ -1877,7 +1881,7 @@ usage: agent-libos mcp auth login [-h] profile_id --profile-file PROFILE_FILE
 | `--profile-file PROFILE_FILE` | yes | `None` | Bounded strict JSON for one pre-registered or CIMD Host profile. |
 | `--scope SCOPE` | no | `[]` | — |
 | `--client-secret-fd CLIENT_SECRET_FD` | no | `None` | Read a bounded client secret from this already-open file descriptor (fd >= 3); never accepts the secret as an argv value. |
-| `--callback-stdin` | no | `False` | Explicitly read one callback URL line from non-interactive stdin; without this flag stdin must be a TTY. |
+| `--callback-stdin` | no | `callback_stdin=False` | Explicitly read one callback URL line from non-interactive stdin; without this flag stdin must be a TTY. |
 
 ## `agent-libos mcp auth logout`
 
@@ -2069,7 +2073,7 @@ usage: agent-libos mcp subscriptions listen [-h] server_id --filter FILTER
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
 | `server_id` | yes | `None` | — |
-| `--filter FILTER` | yes | `None` | — |
+| `--filter FILTER` | yes | `None` | Subscription filter token; repeatable, must be declared in the server manifest. |
 | `--max-events MAX_EVENTS` | no | `None` | Optional positive bound for deterministic foreground completion. |
 | `--max-seconds MAX_SECONDS` | no | `None` | Optional positive foreground lifetime bound. |
 
@@ -2112,7 +2116,7 @@ usage: agent-libos mcp probe [-h] manifest [--confirm-probe] --reviewer REVIEWER
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
 | `manifest` | yes | `None` | — |
-| `--confirm-probe` | no | `False` | Explicitly confirm this Host operation after reviewing its scope. |
+| `--confirm-probe` | no | `mcp_confirmed=False` | Explicitly confirm this Host operation after reviewing its scope. |
 | `--reviewer REVIEWER` | yes | `None` | — |
 | `--reason REASON` | yes | `None` | — |
 
@@ -2150,7 +2154,7 @@ usage: agent-libos mcp scaffold create [-h] base_manifest catalog_json
 | `-h, --help` | no | — | show this help message and exit |
 | `base_manifest` | yes | `None` | — |
 | `catalog_json` | yes | `None` | — |
-| `--confirm-scaffold` | no | `False` | Explicitly confirm this Host operation after reviewing its scope. |
+| `--confirm-scaffold` | no | `mcp_confirmed=False` | Explicitly confirm this Host operation after reviewing its scope. |
 | `--reviewer REVIEWER` | yes | `None` | — |
 | `--reason REASON` | yes | `None` | — |
 
@@ -2167,7 +2171,7 @@ usage: agent-libos mcp scaffold approve [-h] candidate_json [--confirm-review]
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
 | `candidate_json` | yes | `None` | — |
-| `--confirm-review` | no | `False` | Explicitly confirm this Host operation after reviewing its scope. |
+| `--confirm-review` | no | `mcp_confirmed=False` | Explicitly confirm this Host operation after reviewing its scope. |
 | `--reviewer REVIEWER` | yes | `None` | — |
 | `--reason REASON` | yes | `None` | — |
 
@@ -2230,7 +2234,7 @@ usage: agent-libos mcp import apply [-h] bundle_json server_id [--confirm-import
 | `-h, --help` | no | — | show this help message and exit |
 | `bundle_json` | yes | `None` | — |
 | `server_id` | yes | `None` | — |
-| `--confirm-import` | no | `False` | Explicitly confirm this Host operation after reviewing its scope. |
+| `--confirm-import` | no | `mcp_confirmed=False` | Explicitly confirm this Host operation after reviewing its scope. |
 | `--reviewer REVIEWER` | yes | `None` | — |
 | `--reason REASON` | yes | `None` | — |
 
@@ -2684,9 +2688,9 @@ usage: agent-libos store migrate [-h] --to {5,6,7} (--dry-run | --apply)
 | Syntax | Required | Default | Description |
 | --- | --- | --- | --- |
 | `-h, --help` | no | — | show this help message and exit |
-| `--to {5,6,7}` | yes | `None` | — |
-| `--dry-run` | no | `False` | Validate and print the canonical migration plan without writing. |
-| `--apply` | no | `False` | Apply the canonical plan after verifying its digest and backup evidence. |
+| `--to {5,6,7}` | yes | `None` | Target offline Runtime store schema version to plan or apply a migration to. |
+| `--dry-run` | no | `dry_run=False` | Validate and print the canonical migration plan without writing. |
+| `--apply` | no | `apply=False` | Apply the canonical plan after verifying its digest and backup evidence. |
 | `--expected-plan-sha256 EXPECTED_PLAN_SHA256` | no | `None` | Exact plan digest printed by a prior --dry-run; required with --apply. |
 | `--sqlite-backup SQLITE_BACKUP` | no | `None` | Existing verified SQLite backup required before applying a SQLite migration. |
-| `--postgres-snapshot-confirmed` | no | `False` | Confirm an operator snapshot exists before applying a PostgreSQL migration. |
+| `--postgres-snapshot-confirmed` | no | `postgres_snapshot_confirmed=False` | Confirm an operator snapshot exists before applying a PostgreSQL migration. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,8 @@ security rules.
 
 - [Load overlays with the documented precedence](#loading-and-precedence)
 - [Apply bounded YAML input rules](#bounded-yaml-input)
+- [Review store persistence and relative path ownership](#store-persistence-and-relative-path-ownership)
+- [Resolve the effective LLM profile](#effective-llm-profile-precedence)
 - [Inspect exact defaults](#inspecting-exact-defaults)
 - [Configure semantic phases](#semantic-phase-24-configuration)
 - [Review security-sensitive settings](#security-sensitive-settings)
@@ -170,6 +172,8 @@ config = load_config_file("host-overrides.yaml", base=base)
 runtime = Runtime.open(config=config)
 ```
 
+### Store persistence and relative path ownership
+
 The checked-in repository `config.yaml` selects the reserved `user` target and
 loads the trusted PTY Runtime Module. `DEFAULT_CONFIG.runtime.local_store_target`
 is also `user`, so the CLI, directly launched development GUI server, and bare
@@ -241,7 +245,7 @@ legacy mappings are
 `OPENAI_REASONING_EFFORT`; `OPENAI_VERBOSITY`; `OPENAI_SAFETY_IDENTIFIER`;
 `OPENAI_PROMPT_CACHE_KEY`; `OPENAI_PROMPT_CACHE_RETENTION`;
 `OPENAI_PROMPT_CACHE_MODE`; `OPENAI_PROMPT_CACHE_TTL`;
-`OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID`; and
+`OPENAI_RESPONSES_PREVIOUS_RESPONSE_ID`;
 `OPENAI_PARALLEL_TOOL_CALLS`; and `OPENAI_FALLBACK_JSON_ACTIONS`. The default profile also snapshots
 `OPENAI_ENABLE_THINKING` and the OpenAI organization/project routing variables
 (`OPENAI_ORGANIZATION`/`OPENAI_ORG_ID` and
@@ -592,6 +596,28 @@ configurable. A runtime release emits only the snapshot version it can decode.
   the process resource ledger, and surfaced as the corresponding safe Runtime
   timeout/resource-limit result. Arbitrary nested provider text is not added to
   the public error allowlist.
+- Shell command authorization is its own policy surface.
+  `shell.default_policy_level` defaults to `allowlist_auto_else_ask`: argv
+  matched by an allow rule run automatically, and every other command asks the
+  Human rather than being denied or silently allowed. The selectable levels are
+  `always_deny`, `allowlist_auto_else_ask`, `blocklist_ask_else_auto`, and
+  `always_allow`; `always_allow` still cannot convert an `ask`/`deny`
+  capability record or the deterministic destructive-command classifications
+  into automatic allows. The built-in `shell.whitelist` holds eight exact-match
+  read-only inspection argv (the `git status`/`git branch --show-current`/
+  `git rev-parse --show-toplevel`/`git diff --stat` forms and
+  `python`/`python3`/`uv --version`), while `shell.blacklist` holds 48
+  prefix-match high-risk argv rules covering shells, script interpreters,
+  package managers, network tools, and file/permission/system-mutation
+  executables. Hosts may replace or extend those argv lists and attach
+  deterministic `AuthorityRule` entries through `shell.rules`; the rule
+  `conditions` mappings are defensively frozen after load. Whole-shell
+  authority is not a bare command grant: `shell.policy_capability_key`
+  (default `shell_policy_level`) and `shell.policy_resource` (default
+  `shell:*`) name the constraint and resource a shell policy capability must
+  carry. See [Capabilities](capabilities.md) for the complete policy-level
+  evaluation rules and [Tools And Deno/TypeScript JIT](tools_and_jit.md) for
+  the tool surfaces that invoke Shell.
 - Filesystem reads default to `tools.filesystem_read_max_bytes=65536` and are
   capped by `tools.filesystem_read_hard_limit_bytes=1048576`. On Darwin,
   existing workspace entries derive capability, lock, and file-label keys from
@@ -608,8 +634,15 @@ configurable. A runtime release emits only the snapshot version it can decode.
   `git.trusted_metadata_roots` is a Host trust decision for linked-worktree
   metadata and should be as narrow as possible. Remote URL schemes, local file
   remotes, credential-helper inheritance, and SSH-agent inheritance are Host
-  policy; model tools cannot override them. Metadata protection is a fixed
-  invariant: `git.protect_git_metadata` must remain `true`. Disabling Git
+  policy; model tools cannot override them. The shipped defaults are
+  inheritance-on: `git.inherit_credential_helpers` and
+  `git.inherit_ssh_agent` both default to `true`, and
+  `git.allow_scp_style_ssh` defaults to `true` so `user@host:path` SSH remote
+  URLs parse. Compensating defaults keep the remote surface narrow:
+  `git.allow_file_remotes` is `false` and `git.allowed_remote_schemes` is
+  `https`/`ssh`, while metadata protection is a fixed invariant that cannot be
+  disabled: `git.protect_git_metadata` must remain `true`. Deployments running
+  untrusted goals should turn both inheritance switches off. Disabling Git
   or failing executable/version validation affects only Git calls, not Runtime
   startup. See [Git Provider and Primitive](git.md).
 - `llm.persist_full_io` defaults to true. Set it to false when the deployment's
@@ -655,6 +688,21 @@ configurable. A runtime release emits only the snapshot version it can decode.
   `purge_on_terminal` policy reduces readable Run-owned payloads
   to hashes before terminalization; `permanent` is a Host/admin-only per-Run
   choice.
+- `object_tasks.max_running_global` (default `16`) bounds concurrently running,
+  non-terminal ObjectTasks across the Runtime, and
+  `object_tasks.max_running_per_object` (default `4`) bounds them per owner
+  Object. Both must be positive and the global ceiling cannot be smaller than
+  the per-object ceiling. The global value sizes the dedicated ObjectTask tool
+  executor and raises the shared blocking-work supervisor to at least that
+  many workers; each running task additionally holds a spawned runner child
+  process charged against its parent's process child budget, so these ceilings
+  cap concurrent runner processes and their resource-ledger charges, not just
+  threads. A submission that would exceed either ceiling fails immediately
+  with a validation error rather than queueing; the caller must retry once
+  active tasks finish. Shutdown drains the executor for
+  `object_tasks.shutdown_join_timeout_s` (default `2.0` seconds). See
+  [Runtime Model](runtime_model.md#scheduler) and the
+  [Object Task entry point](tools_and_jit.md#object-task-entry-point).
 - Provider-side Responses storage policy remains opt-in through `llm.store`.
   `llm.responses_previous_response_id` permits low-level client chaining policy,
   but the current full-snapshot AgentProcess executor records it as configured

--- a/docs/data_flow.md
+++ b/docs/data_flow.md
@@ -138,6 +138,11 @@ data_flow:
       identity_sha256: "<endpoint-and-method-identity-sha256>"
 ```
 
+Configuration validation pins these defaults: `default_trust_level` must remain
+`untrusted` and `default_max_sensitivity` may only be lowered from `normal`;
+any other value fails config load. Additional clearance can come only from
+explicit `sink_rules`.
+
 Patterns are either exact or a single trailing `*`. Longest match wins;
 duplicate and equal-priority overlapping patterns are rejected. Provider-backed
 LLM, JSON-RPC, MCP, Shell, and PTY clearance above `normal` requires an
@@ -500,9 +505,11 @@ declassification authority, endorsement, Sink clearance, or release row.
 Provider-ingress capture binds the committed result/effect/provider/source
 digests so the suggestion can be reviewed later. The result digest is derived
 only from the SDK's bounded Host canonicalization. The normal path is capped at
-4,096 nodes/256 KiB; six built-in provider domains—Filesystem, Shell, Git,
-JSON-RPC, MCP, and LLM—and Host-bound dataclasses may use a 500,000-node/64 MiB
-incremental streaming digest. The descriptor is
+4,096 nodes/256 KiB; the six provider contract namespaces (Filesystem, Shell, Git, JSON-RPC, MCP, and LLM; `primitive.filesystem.*` through `primitive.llm.*`) and Host-bound dataclasses
+may use a 500,000-node/64 MiB incremental streaming digest. These contract
+namespaces are distinct from the semantic assessment `domain` filter, whose
+values are `filesystem`, `shell`, `git`, `jsonrpc`, `mcp`, `runtime`, and
+`unknown`. The descriptor is
 at most 4 KiB and never contains the result text. If the result is opaque,
 cyclic, ambiguous, or over budget, it reports `digest_unavailable` and semantic
 capture fails closed. Safely traversable provider text is also scanned

--- a/docs/development.md
+++ b/docs/development.md
@@ -339,9 +339,9 @@ uv sync --frozen --no-dev --group release
 uv build --no-build-isolation --clear --out-dir dist --python .venv/bin/python --no-create-gitignore
 .venv/bin/python scripts/check_release_artifacts.py dist --write-checksums
 uv run --frozen --no-dev --group release twine check \
-  dist/agent_libos-1.5.1-py3-none-any.whl dist/agent_libos-1.5.1.tar.gz
+  dist/agent_libos-1.5.2-py3-none-any.whl dist/agent_libos-1.5.2.tar.gz
 uv run --frozen --no-dev --group release check-wheel-contents \
-  dist/agent_libos-1.5.1-py3-none-any.whl
+  dist/agent_libos-1.5.2-py3-none-any.whl
 .venv/bin/python scripts/check_release_artifacts.py dist --verify-checksums
 ```
 

--- a/docs/durable_task_runs.md
+++ b/docs/durable_task_runs.md
@@ -1,6 +1,6 @@
 # Durable Task Runs
 
-Durable Task Runs, introduced in Agent libOS 1.1.0, remain the 1.5.1
+Durable Task Runs, introduced in Agent libOS 1.1.0, remain the 1.5.2
 Host-supervised unit for long-running
 agent work. One `TaskRun` owns one root `AgentProcess` and the child-process
 tree created from that root. The Run adds a durable goal, requirement ledger,
@@ -515,7 +515,7 @@ paged listing, optionally quantum-bounded execution, passive waiting,
 pause/resume, cancellation,
 follow-ups, evidence-constrained recovery, whole-Run rerun operations, and an
 audited `purge_payloads` operation for a terminal `permanent` Run. The explicit
-purge is a Python Host/admin surface in 1.5.1; it is not offered to ordinary
+purge is a Python Host/admin surface in 1.5.2; it is not offered to ordinary
 CLI or GUI users.
 Rerun creates a new Run id and links it to the prior Run; it never rewinds the
 old ledger. After either `purge_on_terminal` cleanup or an explicit Host purge
@@ -532,7 +532,7 @@ its stable client request id instead of an expected revision.
 ## CLI
 
 The `task-run` command group mirrors the ordinary Host controls (the
-Host/admin-only explicit payload purge remains Python-only in 1.5.1):
+Host/admin-only explicit payload purge remains Python-only in 1.5.2):
 
 ```text
 task-run start
@@ -572,10 +572,10 @@ runtime-local execution contract is different. A `needs_attention` Run with an
 unknown effect has no ordinary Retry or Resume button.
 
 The private local API provides `/api/task-runs` collection/detail routes,
-paged ledger and Human-request reads, and run, pause, resume, cancel, follow-up,
+paged ledger and Human-request reads, and run, pause, resume, cancel, follow-ups,
 recover, and rerun mutations. Collection, ledger, and Human pages accept an
 opaque `cursor` and return `next_cursor`; clients must not parse it. There is no
-separate Task Run requirements or wait HTTP route in 1.5.1: the detail response
+separate Task Run requirements or wait HTTP route in 1.5.2: the detail response
 embeds a bounded requirements page selected with `requirements_limit` and
 `requirements_cursor`, requirement changes are also ledger items, and waiting
 is ordinary state observation. Cancel/recover require the same explicit

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,6 +1,6 @@
 # Runtime Events
 
-Agent libOS 1.5.1 persists a closed catalog of `EventType` values. Events
+Agent libOS 1.5.2 persists a closed catalog of `EventType` values. Events
 are durable observations for operators, the GUI, context materialization, and
 Explain evidence. They are not an authority source, a task queue, or a
 replacement for the process, operation, capability, Human-request, or external-
@@ -110,6 +110,47 @@ The public query limit is positive and cannot exceed the import-time
 size. GUI snapshot filtering can hide
 `HUMAN_OUTPUT` events with `purpose=gui_presentation` and matching Human-GUI
 `DATA_FLOW_DECISION` rows; that filter does not delete the durable event.
+
+## Querying events
+
+Events have two supported read surfaces. In Python, `Runtime.events` is the
+`EventBus` facade and `EventBus.list()` is the query API. In the GUI, the SSE
+stream at `GET /api/events/stream` and the workspace views described in the
+[GUI guide](gui.md) consume the same durable rows. There is no `agent-libos
+events` CLI subcommand; the CLI exposes the related evidence surfaces through
+`audit` and `explain` instead.
+
+`EventBus.list()` accepts:
+
+| Parameter | Contract |
+| --- | --- |
+| `target` | Optional string identity filter. A target-filtered query returns exact-target events plus `target=null` broadcasts, as described for the envelope `target` field. |
+| `limit` | Optional positive integer bounded by the fixed query ceiling above. Omitting it returns the complete matching sequence. |
+| `before_event_id` | Opaque cursor selecting the ascending window before this id. Mutually exclusive with `after_event_id`. |
+| `after_event_id` | Opaque cursor selecting the next ascending window after this id. |
+| `include_gui_presentation` | Keyword-only boolean, default `True`. Passing `False` applies the GUI snapshot filter described above to this query result: `HUMAN_OUTPUT` events with `purpose=gui_presentation` and their matching Human-GUI `DATA_FLOW_DECISION` rows are hidden. The durable rows are unaffected. |
+
+A minimal Host polling consumer:
+
+```python
+from agent_libos import Runtime
+
+runtime = Runtime.open("local")
+try:
+    snapshot = runtime.events.list(limit=100)
+    cursor = snapshot[-1].event_id if snapshot else None
+    for event in snapshot:
+        print(event.created_at, event.type, event.source, event.target)
+    # A later poll returns only events persisted after the stored cursor.
+    if cursor is not None:
+        fresh = runtime.events.list(limit=100, after_event_id=cursor)
+        print(len(fresh), "new events")
+finally:
+    runtime.shutdown()
+```
+
+Persist the returned `event_id` as the cursor between invocations; an unknown
+cursor returns an empty page rather than failing.
 
 ## Idempotent publication
 

--- a/docs/evidence_payload_retention.md
+++ b/docs/evidence_payload_retention.md
@@ -204,7 +204,11 @@ agent-libos --config config.yaml --db user payload-retention external_effect --a
 ```
 
 Use the returned `next_cursor.created_at` and `next_cursor.record_id` as
-`--after-created-at` and `--after-record-id` for the next page. Startup only
+`--after-created-at` and `--after-record-id` for the next page. An optional
+`--limit` bounds the page within the policy hard limit. `--actor` overrides the
+default `host.retention` actor identity, and `--correlation-id` attaches a
+Host-supplied correlation id; both are recorded on the audited maintenance
+summary. Startup only
 constructs the maintenance service; it never invokes a scan or mutation.
 
 Every call is bounded. A page is ordered by `(created_at, record_id)` and may

--- a/docs/explainable_operations.md
+++ b/docs/explainable_operations.md
@@ -253,6 +253,6 @@ or explicitly sanitize provider-specific secret formats. Explain rendering
 leaves the original audit and external-effect records unchanged; it does not
 rewrite their source fields while producing a redacted projection.
 
-Unlinked rows are not backfilled or heuristically reconstructed. The 0.3
-schema requires the explanation tables and explicit links; an older or
-incomplete store is rejected before mutation.
+Unlinked rows are not backfilled or heuristically reconstructed. The frozen
+schema-v7 RuntimeStore contract requires the explanation tables and explicit
+links; an older or incomplete store is rejected before mutation.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -14,19 +14,29 @@ Several independent version namespaces coexist. Never infer one from another:
 
 | Namespace | Current value | What it versions |
 | --- | --- | --- |
-| Agent libOS product/package | `1.5.1` | Python package, aligned GUI package, release workflow, and current product contract |
+| Agent libOS product/package | `1.5.2` | Python package, aligned GUI package, release workflow, and current product contract |
 | RuntimeStore schema | `7` | Persisted SQL store shape accepted by ordinary Runtime startup |
 | GUI snapshot envelope | `3` | Same-build `GET /api/snapshot` response consumed by the bundled renderer |
 | GUI JSON Schema registry | `2` | The deliberately partial registry in [`gui_api_schema.json`](gui_api_schema.json); it describes selected v3 snapshot/API shapes and confirmed mutations, not a complete REST API |
 | MCP manifest | `1`, `2`, or `3` | Independent client manifest contracts; v1/v2 preserve governed Tool compatibility and v3 requires the exact `2026-07-28` protocol contract |
+| LLM prompt layout / prompt-cache | `legacy_v1`, `cache_optimized_v2` | `llm.prompt_layout` tokens plus the opt-in v2 prompt-cache transport (`prompt_cache_options`, the `30m` TTL, derived `alibos:v2:` keys); bare prompt-caching v2 in the docs means this namespace, not an MCP manifest version |
 | Runtime-safety benchmark task | `1` | Checked-in benchmark task YAML input |
 | Runtime-safety run output | `2` | One runner's persisted benchmark result/effect artifact |
 
 Checkpoint snapshots, image artifacts, events, semantic records, migration
 plans, and other payloads have additional local schema versions. A field named
 `schema_version` must always be interpreted in the type and subsystem that owns
-it. See [Storage](storage.md), [GUI](gui.md#api-contract-boundary),
-[MCP](mcp.md), and [Benchmark](benchmark.md) for their separate contracts.
+it. Subsystem-local values the Runtime currently declares beyond this map
+include task-run reference payloads (`1`), process tool completion-review and
+acknowledged-message reference payloads (`2`), prompt-cache release-gate
+reports (`1`), LLM provider traces (`1`), GUI-authored LLM user profiles
+(`1`), LLM context-memory snapshot and compaction records (`1`), and the
+public semantic-status projection (`3`). That last value shares its number
+with the unrelated GUI snapshot envelope `3` above; equal numbers across
+namespaces never imply a shared contract, and individual modules may declare
+further private marker versions. See [Storage](storage.md),
+[GUI](gui.md#api-contract-boundary), [MCP](mcp.md), and [Benchmark](benchmark.md)
+for their separate contracts.
 
 ## Runtime and execution
 
@@ -104,12 +114,32 @@ A progressively disclosed instruction/resource package that may change a
 process's prompt context and tool visibility. Activating a Skill is not a
 Capability grant. See [Skills](skills.md).
 
+### Tool Skill
+
+An immutable built-in Skill whose role is on-demand tool projection: it owns a
+fixed group of built-in static tools and supplies intent-focused guidance plus
+only the image-authorized tool schemas needed for the current task. Under an
+image's `tool_projection: skills` contract the model starts from a small
+bootstrap projection and reaches other tools through Tool Skill discovery and
+activation. Legacy Tool Group metadata is converted only by the explicit
+offline `agent-libos-migrate-tool-groups` migration. See
+[Tools and Deno/TypeScript JIT](tools_and_jit.md#on-demand-tool-skills).
+
 ### Tool
 
 A named, schema-validated action exposed through ToolBroker. A complete process
 tool table determines what can be called; the model projection is a potentially
 narrower visible subset. Visibility never substitutes for primitive authority.
 See [Tools and Deno/TypeScript JIT](tools_and_jit.md).
+
+### ToolBroker
+
+The trusted dispatcher for the complete process tool table. It validates every
+call against the exact registered schema and dispatches it to the owning tool
+implementation, while the model-facing projection may be narrower than the
+callable table. Passing broker validation is visibility mediation, not
+resource authority; the owning primitive still authorizes each effect. See
+[Tools and Deno/TypeScript JIT](tools_and_jit.md).
 
 ### JIT tool
 
@@ -194,6 +224,22 @@ activities, edges, monotonic label assertions, source references, and coverage
 without copying the underlying content. It is evidence for assessment and review,
 not an authority graph. See [Semantic Approval and Data Identification](semantic_shadow.md).
 
+### Provider contract namespace
+
+The set of provider primitive prefixes (`primitive.filesystem.`,
+`primitive.shell.`, `primitive.git.`, `primitive.jsonrpc.`,
+`primitive.mcp.`, `primitive.llm.`) whose operations qualify results for the
+digest contract. Six exist; `primitive.llm.` is the only one with no matching
+[semantic assessment domain](#semantic-assessment-domain). The word "domain"
+here is a namespace prefix, not the assessment filter below.
+
+### Semantic assessment domain
+
+The closed enum used by the semantic classifier, the CLI `--domain` filter, and
+the `by_domain` contract: `{filesystem, shell, git, jsonrpc, mcp, runtime,
+unknown}`. It omits `llm` and adds `runtime`/`unknown`, so it is not the same
+set as the provider contract namespaces despite the shared word "domain".
+
 ## Effects and evidence
 
 ### Primitive
@@ -217,6 +263,16 @@ A Host-visible causal record representing one logical Runtime action across its
 LLM, Tool, syscall, primitive, Capability, Human, provider, resource, event, and
 audit stages. An operation tree explains relationships; its existence does not
 authorize a future action. See [Explainable Operations](explainable_operations.md).
+
+### Protected operation
+
+An effectful Runtime action that must enter its owning trusted primitive or
+`agent_libos.sdk` boundary. That boundary enforces process identity, Capability
+reservation, Task Authority ceilings, policy, approval, data flow, budgets,
+provider-effect classification, and event/audit evidence as one fail-closed
+state machine. Tool or model visibility of the action is never a substitute
+for entering this boundary. See
+[Protected Operation SDK](protected_operation_sdk.md).
 
 ### External effect
 

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -130,8 +130,9 @@ authenticated local Host/admin authority boundary over the same primitives,
 Capability checks, human approval flow, events, and audit records used by the
 CLI. Possession of its bearer token authorizes every Host/admin route the
 server dispatches, not only the endpoints enumerated in this guide's API
-Summary; the server dispatch table and the machine-readable [GUI API contract
-subset](gui_api_schema.json) registry are the definitive route inventory.
+Summary. The server dispatch table is the authoritative route inventory; the
+machine-readable [GUI API contract subset](gui_api_schema.json) is a partial
+payload contract and must not be used to infer which routes exist.
 Actor-mode routes instead use the selected process's authority. Its
 Python entrypoint lives under
 `agent_libos.api.gui` with the CLI because both are host-facing API surfaces.
@@ -920,9 +921,10 @@ server handlers and GUI tests.
 
 This summary lists important endpoints, but it is deliberately not exhaustive
 and is not the authorization inventory: the bearer token authorizes every
-route the server dispatches. Treat the server dispatch table and the
-machine-readable [contract registry](gui_api_schema.json) as the definitive
-route inventory.
+route the server dispatches. Treat the server dispatch table as the
+authoritative route inventory; the machine-readable [contract
+registry](gui_api_schema.json) validates only the documented subset described
+above.
 
 Important endpoints:
 

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -30,12 +30,14 @@ Deno visible without changing Electron's own environment.
 ## In this guide
 
 - [Complete a first task](#first-task-user-path)
+- [Review the architecture](#architecture)
 - [Develop and test the GUI](#development)
 - [Build the internal desktop distribution](#self-contained-internal-desktop-distribution)
 - [Understand the user and operator workspace](#current-workspace)
 - [Inspect semantic evidence](#semantic-panel)
 - [Review high-risk operations](#high-risk-operations)
 - [Use the API contract boundary and summary](#api-contract-boundary)
+- [Consult the API summary](#api-summary)
 - Return to the [documentation home](index.md).
 
 ## First task: user path
@@ -126,8 +128,11 @@ request and its later approved/rejected/cancelled version each produce a
 The GUI server is not a separate process-effect boundary. It is an
 authenticated local Host/admin authority boundary over the same primitives,
 Capability checks, human approval flow, events, and audit records used by the
-CLI. Possession of its bearer token authorizes the documented Host/admin
-routes; actor-mode routes instead use the selected process's authority. Its
+CLI. Possession of its bearer token authorizes every Host/admin route the
+server dispatches, not only the endpoints enumerated in this guide's API
+Summary; the server dispatch table and the machine-readable [GUI API contract
+subset](gui_api_schema.json) registry are the definitive route inventory.
+Actor-mode routes instead use the selected process's authority. Its
 Python entrypoint lives under
 `agent_libos.api.gui` with the CLI because both are host-facing API surfaces.
 Only a bearer token holder on the same machine can use it; CORS is limited to
@@ -273,8 +278,9 @@ uv run python scripts/test_matrix.py --lane gui
 ```
 
 The browser end-to-end suite also needs the lock-installed Playwright package
-and its version-matched Chromium binary. `npm ci` above installs the JavaScript
-package; it does not download the browser executable. For CI/Linux parity,
+and its version-matched Chromium binary. The `npm --prefix gui ci` step below
+installs the JavaScript package; it does not download the browser executable.
+For CI/Linux parity,
 install both Chromium and its operating-system dependencies before running the
 suite:
 
@@ -327,14 +333,21 @@ The development Electron smoke path can be run headlessly with
 `AGENT_LIBOS_GUI_SMOKE=1`. By default it verifies the Electron main process,
 Python GUI server startup, authenticated `/api/health`, and graceful shutdown
 against an in-memory `local` store without creating a BrowserWindow. Smoke
-logging redacts the temporary bearer token. Set
+logging redacts the temporary bearer token. `AGENT_LIBOS_GUI_SMOKE_PERSIST=1`
+instead starts the server against the persistent default store target (`user`
+from a checkout, the packaged user-data database in the internal desktop
+smoke). `AGENT_LIBOS_GUI_SMOKE_LOG=<path>` additionally appends every smoke
+JSON log line to that file, and `AGENT_LIBOS_GUI_SMOKE_USER_DATA=<dir>`
+relocates the Electron user-data directory (by default
+`gui/.smoke-user-data` in a checkout, or a per-process temp directory when
+packaged); the native desktop smoke sets all three. Set
 `AGENT_LIBOS_GUI_SMOKE_WINDOW=1` when a machine has a working desktop/GPU stack
 and you specifically want to exercise the production Vite build through the
 custom-protocol BrowserWindow, its API origin, and the preload bridge.
 
 ## Self-contained internal desktop distribution
 
-Agent libOS 1.5.1 also has a manually triggered, internal-only native desktop
+Agent libOS 1.5.2 also has a manually triggered, internal-only native desktop
 build for macOS arm64, Windows x64, and Ubuntu 24.04/glibc x64. The exact
 runtime closure is Electron 43.2.0, a PyInstaller 6.21.0 one-folder sidecar
 built with CPython 3.11.15, Agent libOS with the complete MCP extra (including
@@ -789,8 +802,9 @@ operations before invoking the runtime:
 - JSON-RPC endpoint registration and method calls,
 - MCP server registration, unregistration, and tool calls,
 - accepting an MCP Prompt preview as untrusted user context, OAuth login/logout,
-  Elicitation continuation response/cancellation, remote Task update/cancellation,
-  and subscription start/stop,
+  OAuth profile add/replace/remove, Elicitation continuation
+  response/cancellation, remote Task update/cancellation, and subscription
+  start/stop,
 - Skill registration, activation, and unload,
 - Durable Task Run cancellation and evidence-constrained recovery.
 
@@ -865,8 +879,10 @@ machine-readable [GUI API contract subset v2](gui_api_schema.json)
 deliberately covers the snapshot's required top-level collections, the minimal
 process/scheduler shape and TaskRun launch availability consumed during
 bootstrap, redacted Task Run
-summary/detail state, the JSON error envelope, and payloads for every operation
-that the server gates with explicit confirmation.
+summary/detail state, the JSON error envelope, payloads for every operation
+that the server gates with explicit confirmation, and the Host-only MCP v3
+operation request payloads and result projections (the
+`mcp_v3_host_operations` scope).
 `GET /api/snapshot` emits `schema_version: 3`; this same-build renderer rejects
 older snapshot shapes instead of treating summary-only LLM state or Task Run
 state as an empty collection. Version 3 replaces full LLM rows in snapshot/SSE
@@ -901,6 +917,12 @@ same-build implementation details and must be changed together with their
 server handlers and GUI tests.
 
 ## API Summary
+
+This summary lists important endpoints, but it is deliberately not exhaustive
+and is not the authorization inventory: the bearer token authorizes every
+route the server dispatches. Treat the server dispatch table and the
+machine-readable [contract registry](gui_api_schema.json) as the definitive
+route inventory.
 
 Important endpoints:
 
@@ -942,7 +964,7 @@ Important endpoints:
   Collection, ledger, and Human pages accept opaque `cursor` values and return
   `next_cursor`; clients must not parse or synthesize them. The embedded
   requirements page also returns `next_cursor`. Requirement changes are linked
-  ledger items, and 1.5.1 has no independent Task Run requirements or wait HTTP
+  ledger items, and 1.5.2 has no independent Task Run requirements or wait HTTP
   route.
 - `POST /api/task-runs/{run_id}/run|pause|resume|cancel|follow-ups|recover|rerun`.
   Every existing-Run mutation carries a command id and expected revision.

--- a/docs/gui_api_schema.json
+++ b/docs/gui_api_schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agent-libos.local/schemas/gui-api/v2.json",
   "title": "Agent libOS local GUI API contract subset v2",
-  "description": "Machine-readable same-build schema registry for the snapshot's top-level structure and non-secret TaskRun launch availability, process identity/state, content-free LLM call summaries, redacted Durable Task Run summaries/details, JSON error envelopes, and explicit-confirmation mutation payloads. The document root deliberately rejects instances: validators must select one of the named $defs entry points with a JSON Pointer fragment. Snapshot collection item semantics outside process, LLM call, and Task Run state remain renderer/server implementation details. This is not a complete public REST/OpenAPI specification.",
+  "description": "Machine-readable same-build schema registry for the snapshot's top-level structure and non-secret TaskRun launch availability, process identity/state, content-free LLM call summaries, redacted Durable Task Run summaries/details, JSON error envelopes, explicit-confirmation mutation payloads, and Host-only MCP v3 operation request payloads and result projections (the mcp_v3_host_operations scope). The document root deliberately rejects instances: validators must select one of the named $defs entry points with a JSON Pointer fragment. Snapshot collection item semantics outside process, LLM call, and Task Run state remain renderer/server implementation details. This is not a complete public REST/OpenAPI specification.",
   "x-agent-libos-schema-version": 2,
   "x-agent-libos-contract-scope": {
     "snapshot": "GET /api/snapshot",

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -364,7 +364,7 @@ longer defines.
   pre-commit phase and CASes RUNNING status, generation, owner, and lease. These
   typed boundaries compute the next state generation, preventing a direct-write
   rewind from reviving a stale token.
-- `v7-persisted-state-is-strict-and-versioned`: ordinary 1.5.1 Runtime startup
+- `v7-persisted-state-is-strict-and-versioned`: ordinary 1.5.2 Runtime startup
   accepts only the frozen version-7 physical schema (including Durable Task
   Run, typed process state, Human revision, semantic job/evidence state,
   FlowGraph, policy epochs, machine-settlement evidence, and sanitized MCP v3
@@ -598,8 +598,9 @@ longer defines.
   visible process; GUI-level omissions detected by lookahead remain explicit in
   `_truncated`, while stricter subsystem list maxima remain authoritative.
   Persisted indexed visibility flags exclude internal presentation evidence
-  before `LIMIT`; missing or malformed required 0.3 visibility state fails
-  closed instead of being repaired during open.
+  before `LIMIT`; missing or malformed required `gui_snapshot_visible` state
+  (the frozen schema-v7 store contract) fails closed instead of being
+  repaired during open.
 - `tool-observability-redacts-sensitive-payloads`: tool audit/event
   observability redacts known structured payload/credential keys plus recognized
   scalar credential forms, URI/DSN userinfo, and HTTP Cookie headers before it

--- a/docs/jsonrpc.md
+++ b/docs/jsonrpc.md
@@ -435,6 +435,13 @@ any part fails, the old endpoint spec remains active. Unregistering an endpoint
 applies the same endpoint-specific invalidation in the same transaction, so
 reusing the same endpoint id cannot revive stale method authority.
 
+`jsonrpc call` prints the structured `JsonRpcCallResult` and exits with status
+0 even when that result carries `jsonrpc_error` or `transport_error`: the
+structured result is the command's deliverable, so scripts must inspect the
+printed `status`/`ok` fields rather than the exit code. The MCP group
+deliberately differs — `mcp` subcommands exit 1 when their envelope reports
+`ok: false`. See [CLI](cli.md#json-rpc-commands) for the full command contract.
+
 ## Tools And Syscalls
 
 LLM tool interfaces, when bound in the complete process table and projected into

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -27,6 +27,7 @@ extension without silently reinterpreting v1/v2.
 - Interpret results in [Call And Tool-List Results](#call-and-tool-list-results).
 - Operate and diagnose through the [CLI](#cli) and
   [Host DX workflow](#host-dx-workflow).
+- Review the projected surfaces in [Tools And Syscalls](#tools-and-syscalls).
 - Check lifecycle boundaries in [Persistence And Checkpoints](#persistence-and-checkpoints).
 
 Manifest schema, MCP wire protocol, SDK, product, and Store versions are
@@ -56,7 +57,7 @@ distribution metadata:
 | --- | --- | --- |
 | v1 legacy wire | `mcp` | `0.1.0` |
 | v2 governed Tools compatibility | `agent-libos` | `1.4.2` |
-| v3 exact `2026-07-28` | `agent-libos` | `1.5.1` |
+| v3 exact `2026-07-28` | `agent-libos` | `1.5.2` |
 
 The v1 and v2 values are frozen compatibility identities. Only exact-v3 uses
 the current modern product identity; changing the package version must never
@@ -352,7 +353,12 @@ status/begin/complete/revoke/logout, PKCE/state and token custody, while the
 transport receives only the selected access token through a private broker.
 An `auth_profile_id` cannot coexist with a manifest static `Authorization`
 header; that ambiguous dual-credential configuration is rejected during
-offline validation and registration, before provider work.
+offline validation and registration, before provider work. On dispatch, the
+selected access token reaches the governed transport only as the synthetic
+`AGENT_LIBOS_INTERNAL_MCP_OAUTH_TOKEN` entry inside that operation's
+provider-phase environment snapshot; a value supplied under that name through
+a manifest or the Host environment is rejected by the default env allowlists,
+and the entry is redacted like the underlying lease secrets.
 
 The optional `subscriptions` array is a closed subset of
 `toolsListChanged`, `promptsListChanged`, `resourcesListChanged`,
@@ -841,14 +847,21 @@ register/replace/unregister with the interval from that live compare through
 provider-call return; the runtime's single-writer store lease excludes a second
 supported Runtime writer from bypassing the in-process guard.
 
-Tool binding and model visibility are not authority. Built-in Images that
-support MCP bind the four server/Tool entries plus the two v3 Resource
-list/read entries in their complete process tool tables. Their Skill projection
-keeps those tools out of the model table until the exact
-`agent-libos-mcp` Skill is activated. Toolmaker and context-compressor do not
-bind these tools and cannot activate that immutable built-in Skill. Neither
-static binding nor later projection lets a process inspect or call a registered
-server without the matching capability.
+Tool binding and model visibility are not authority. With `DEFAULT_CONFIG`,
+the complete process tool tables for `base-agent:v0`, `coding-agent:v0`, and
+`review-agent:v0` bind the four server/Tool entries plus the two v3 Resource
+list/read entries. Their initial Skill projection contains only the five
+bootstrap tools, so none of these MCP schemas is initially model-visible;
+activating the exact `agent-libos-mcp` Skill projects them without changing
+Capability authority. The narrow direct `research-agent:v0`,
+`analysis-agent:v0`, and `operator-agent:v0` images expose the same six
+schemas at boot because their workflow domain is Host-selected in advance;
+calls still require the exact server/Tool or Resource Capability and Task
+Authority. `maintenance-agent:v0`, `toolmaker-agent:v0`, and
+`context-compressor:v0` do not bind these tools and cannot activate that
+immutable built-in Skill. Custom or committed Images may choose another
+complete table/projection. Neither static binding nor later projection lets a
+process inspect or call a registered server without the matching capability.
 
 ## Data-flow Sink
 
@@ -1276,6 +1289,16 @@ shipped at the repository root. The placeholder server/module and reserved
 HTTP hostname in the manifest examples will not make these commands a live
 remote demo.
 
+Exit status follows the structured envelope: every `mcp` subcommand prints its
+JSON result and then exits with status 1 when that envelope reports
+`ok: false` — for `mcp call` that includes `mcp_error` and `transport_error`
+results, so the printed JSON names the exact outcome. The parallel
+`jsonrpc call` command deliberately differs: it prints its
+`JsonRpcCallResult` and exits 0 even when the result carries `jsonrpc_error`
+or `transport_error`, because the structured result is the deliverable and
+scripts must inspect its `status`/`ok` fields rather than the exit code. The
+general CLI exit-code contract is described in [CLI](cli.md#mcp-commands).
+
 `mcp list` accepts `--text` and `--limit` and returns an envelope
 `{"servers": [...], "has_more": <bool>}`. `has_more: true` means the bounded
 window is incomplete; this command has no cursor, so narrow `--text` or raise
@@ -1413,6 +1436,15 @@ non-registerable candidate wrapper; an operator must edit/review it and run the
 separate `approve --confirm-review` transition before extracting a registerable
 manifest. Confirmation never bypasses Runtime Capability, data-flow, effect,
 or resource checks.
+
+Each workflow above is also available as a built-in `agent-libos mcp`
+subcommand (see the table earlier in this section): `mcp validate`,
+`mcp doctor`, and `mcp probe` take the manifest path; `mcp scaffold create`
+and `mcp scaffold approve` replace the flat `scaffold` and `approve` script
+modes; and `mcp export`, `mcp import plan`, and `mcp import apply` replace
+`export`, `import-plan`, and `import-one`. Both surfaces share the same
+`agent_libos.mcp.dx` implementation, confirmation flags, and
+reviewer/reason evidence.
 
 ## Tools And Syscalls
 

--- a/docs/mini_swe_agent_image.md
+++ b/docs/mini_swe_agent_image.md
@@ -1,10 +1,14 @@
 # mini-swe-agent Image
 
+## Package overview
+
 `images/mini-swe-agent/` is a package-only AgentImage inspired by the single
 `bash` tool-call shape historically associated with mini-swe-agent's
 `mini.yaml`. The model sees one `bash` tool with a required `command` string and
 an optional `submit` boolean. This package does not claim drop-in or versioned
 compatibility with an unpinned upstream revision.
+
+## Validate and register
 
 ```bash
 uv run agent-libos --db user images validate images/mini-swe-agent
@@ -19,11 +23,15 @@ silently omitting the `bash` tool. Executing the tool separately requires the
 Host Shell provider to resolve and permit a usable `bash` executable because
 the mediated command is `bash -lc ...`; Deno itself does not supply Bash.
 
+## Prompt mode and transcript persistence
+
 This image uses `prompt_mode: image_only`. Every LLM turn therefore requires
 `llm.persist_full_io: true`, the default, so the Runtime can retain and validate
 the lossless native assistant/tool transcript. With
 `llm.persist_full_io: false`, boot may register the image, but execution fails
 closed before LLM provider dispatch rather than falling back to a lossy prompt.
+
+## CLI store selection
 
 The CLI loads the project-root `config.yaml` when it is present. In this
 checkout that configuration selects `user`, so omitting `--db` persists the
@@ -35,6 +43,8 @@ directory and are rejected inside the effective workspace; use `user` or an
 absolute external path when invocations must select the same store independently
 of local configuration.
 
+## Tool surface
+
 The package uses `prompt_mode: image_only`, `jit_tool_exposure: direct`, and
 `default_tools: []`. At boot, the image package registers one process-local JIT
 tool named `bash`; it does not expose `process_exit`, Object Memory, or other
@@ -42,6 +52,8 @@ builtin tools to the model. If `submit` is `true` and the shell command exits
 successfully, the JIT wrapper calls the internal `process.exit` syscall with
 the same bounded structured observation returned by the tool. It never copies
 an oversized raw shell result into the final process payload.
+
+## Shell mediation boundary
 
 The wrapper runs:
 
@@ -60,6 +72,8 @@ the Bash subprocess. A Host executing untrusted code must put the Shell
 provider or workspace behind an explicit container, WASM, VM, service-provider,
 or comparable filesystem/network isolation boundary.
 
+## Bounds and contract tests
+
 The wrapper uses a 30 second shell timeout, a 32,768-Unicode-code-point command limit, and a
 10,000-code-point observation window. The JSON Schema validator and TypeScript
 wrapper use the same unit, so astral characters such as emoji count once and
@@ -73,6 +87,8 @@ shell syscall, a failed final submission, and propagation of upstream shell
 truncation, plus the rule that a non-zero command cannot submit, before
 registering the tool.
 
+## Required capability declarations
+
 The package declares required capabilities for workspace filesystem read/write
 and shell execute authority. Bootstrap validates and records those declarations
 in the task authority manifest, and exposes any unsatisfied entries through
@@ -81,6 +97,8 @@ not launch gates or grants: missing entries do not prevent spawn/boot, and the
 declarations do not create live authority. A Host or benchmark runner must still
 grant the spawned process the filesystem and shell authority it should have for
 the task.
+
+## Observation and submission semantics
 
 Every command observation propagates `stdout_truncated` and
 `stderr_truncated` from the shell primitive. `output_incomplete` is true when
@@ -104,6 +122,8 @@ the shell command succeeds but the final process-exit syscall fails, the tool
 returns a non-zero observation that retains the same bounded command-output and
 truncation evidence and reports the submission failure; it does not claim
 completion.
+
+## Compatibility scope
 
 The compatibility scope is intentionally only the local single-tool idea. Key
 Agent libOS-specific behavior includes:

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -610,6 +610,14 @@ module, so list it without repeating the manifest on the command line:
 uv run agent-libos --db local modules list
 ```
 
+Inspect one loaded module's recorded summary, including status,
+manifest/source hashes, entrypoint, registered surfaces, and metadata, by
+exact module id:
+
+```bash
+uv run agent-libos --db local modules inspect example-module:v0
+```
+
 On a Host whose configuration does not already list that manifest, pass
 `--module-manifest modules/pty/module.yaml` together with the exact
 `--trusted-module <trust_key>` returned by `modules verify`. Do not combine a

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -615,7 +615,7 @@ manifest/source hashes, entrypoint, registered surfaces, and metadata, by
 exact module id:
 
 ```bash
-uv run agent-libos --db local modules inspect example-module:v0
+uv run agent-libos --db local modules inspect agent-libos-pty:v0
 ```
 
 On a Host whose configuration does not already list that manifest, pass

--- a/docs/object_memory.md
+++ b/docs/object_memory.md
@@ -6,11 +6,14 @@ It is not a plain key/value store and object names are not capabilities.
 ## In this guide
 
 - [Objects](#objects)
+- [Namespaces](#namespaces)
 - [Name resolution](#name-resolution)
 - [Query API](#query-api)
 - [Memory Views](#memory-views)
+- [Object Links](#object-links)
 - [Object Tasks](#object-tasks)
 - [File/Object bridge](#fileobject-bridge)
+- [Data labels and provenance](#data-labels-and-provenance)
 - [Context materialization](#context-materialization)
 - [Persistence invariant](#persistence-invariant)
 - Return to the [documentation home](index.md).
@@ -627,6 +630,13 @@ prevents compressor children and their summaries from immediately retriggering
 the maintenance they just completed. The projection is still checked before
 persistence, and a first post-compaction projection that already reaches the
 hard limit fails instead of entering an ineffective retry loop.
+
+Selection order comes from `memory.context_policy`, whose default is
+`plan_first`: goal, task, plan, and step objects are ordered ahead of the rest.
+`evidence_first`, `recency_first`, and `error_debug` are the other supported
+orderings, and an Image may select its own policy. One materialization pass is
+bounded by `memory.materialize_budget_tokens` (8,000 tokens by default), again
+capped by the per-call window and cumulative budget described below.
 
 Materialization budgets use the final rendered object text, not stored
 `metadata.token_estimate`. Object creation, payload updates, file imports, and

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -13,6 +13,15 @@ composition is `LocalResourceProviderSubstrate` from
 provider hooks during startup. Every real provider boundary must use the
 [`ProtectedOperationContract`](protected_operation_sdk.md) lifecycle.
 
+## In this guide
+
+- [Python composition boundary](#python-composition-boundary)
+- [Current provider inventory](#current-provider-inventory)
+- [Failure semantics](#failure-semantics)
+- [Registration and visibility](#registration-and-visibility)
+- [Provider extension checklist](#provider-extension-checklist)
+- Return to the [documentation home](index.md).
+
 ## Python composition boundary
 
 Import the public structural protocols and default composition from
@@ -208,7 +217,11 @@ and the configured privacy domain without a Run or process id. The only v2 TTL
 is `30m`, and it is mutually exclusive with legacy `prompt_cache_retention`.
 See the [OpenAI prompt-caching guide](https://developers.openai.com/api/docs/guides/prompt-caching).
 
-The maintenance, browser, and knowledge live evaluators accept
+The repository-maintenance
+(`experiments/run_durable_task_run_evaluation.py` and
+`experiments/run_long_horizon_evaluation.py`), browser
+(`experiments/run_browser_customer_flow_evaluation.py`), and knowledge
+(`experiments/run_knowledge_workflow_evaluation.py`) live evaluators accept
 `--prompt-layout`, and their redacted reports aggregate total input/output,
 cache reads, cache writes, uncached input, completion evidence, and forbidden
 Host-identifier counts. Build one arm from two or more provider reports with a

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -12,6 +12,7 @@ at the end of this page is part of the API contract.
 - [Use Runtime managers and primitives](#runtime-managers-and-primitives)
 - [Inspect semantic evidence and settlement](#semantic-evidence-control-and-settlement-boundary)
 - [Use JSON-RPC and MCP Host APIs](#json-rpc-and-mcp-host-apis)
+- [Inject provider protocols](#provider-protocols-and-injection)
 - [Handle common exceptions](#common-exceptions)
 - [Apply the compatibility boundary](#compatibility-boundary)
 - Return to the [documentation home](index.md).
@@ -380,11 +381,17 @@ Within the first layer, the complete public Host evidence/review surface is:
 | `runtime.semantic.query_health_events(*, after=None, limit=None, severity=None, code=None, epoch_id=None)` | keyset page `dict[str, Any]` |
 | `runtime.semantic.append_review_label(*, settlement_id, outcome, reviewer_id, evidence_sha256, reviewed_at=None)` | appended review-evidence `dict[str, Any]` |
 
-Paged queries are hard-bounded and keyset-paged. The
-omitted direct-Host limit uses `semantic.assessment_list_limit`; an explicit
-limit cannot exceed the smaller of `semantic.assessment_list_hard_limit` and
-500. The CLI and local HTTP API apply their stricter 50-row default and 100-row
-maximum.
+Paged queries are hard-bounded and keyset-paged, with three limit groups.
+Assessment queries (`query_assessments`) use `semantic.assessment_list_limit`
+as the omitted direct-Host default; flow queries (`query_flow_entities`,
+`query_flow_edges`, `query_flow_lineage`) use `semantic.flow_query_limit`; and
+settlement-family queries (`query_machine_settlements`, `query_policy_epochs`,
+`query_control_history`, `query_health_events`) use
+`semantic.settlement_list_limit`. In each group an explicit limit cannot
+exceed the smaller of the matching hard limit
+(`semantic.assessment_list_hard_limit`, `semantic.flow_query_hard_limit`, or
+`semantic.settlement_list_hard_limit`) and 500. The CLI and local HTTP API
+apply their stricter 50-row default and 100-row maximum.
 The returned mappings are payload-free projections containing typed findings,
 Shadow outcome, normalized Human observation, calibration, reserved nullable
 token/cost fields, and provenance digests. An external classifier may populate
@@ -599,6 +606,7 @@ from agent_libos.models.exceptions import (
 | `HumanApprovalRequired` / `HumanResponseRequired` | The operation is waiting for a durable Human decision or answer; the exception carries `request_id` |
 | `ProcessWaitRequired` / `ProcessMessageWaitRequired` | A resumable operation is waiting for a child process or process message |
 | `ResourceLimitExceeded` | A configured process or hierarchical resource budget would be exceeded |
+| `ProcessRevisionConflict` / `TaskRunRevisionConflict` / `TaskRunCommandConflict` | A compare-and-swap fence rejected the mutation: the expected process or Durable Task Run revision was stale, or a Task Run command id was reused for a different canonical request; retry with the current revision and the same command id under the revision/command-id contract in [Durable Task Runs](durable_task_runs.md) |
 | `GitError` | Stable typed Git failure; inspect `code`, `operation`, `retryable`, and bounded `details` |
 | `ProviderHostError` | Sanitized provider exception with `code`, `error_type`, and `correlation_id`; raw provider text is not part of the public error |
 | `UnsupportedStoreVersion` | The target store is not compatible with the strict current schema |
@@ -622,7 +630,7 @@ cannot silently abandon an owned store or partially assembled component graph.
 
 ## Compatibility boundary
 
-- Agent libOS 1.5.1 is experimental. The top-level `agent_libos.__all__` names
+- Agent libOS 1.5.2 is experimental. The top-level `agent_libos.__all__` names
   and the Runtime entrypoints documented here are the intended application
   import surface for this release. Pin the package version when depending on
   exact signatures or dataclass fields.

--- a/docs/release_status.md
+++ b/docs/release_status.md
@@ -1,6 +1,6 @@
-# Agent libOS 1.5.1 Status
+# Agent libOS 1.5.2 Status
 
-Agent libOS 1.5.1 is the current release line for the core Python runtime scope
+Agent libOS 1.5.2 is the current release line for the core Python runtime scope
 defined in the [support matrix](support_matrix.md). Release status for any source tree is
 conditional on that exact tree passing the checked-in CI workflow; local
 deterministic results do not substitute for its Python-version, PostgreSQL, and
@@ -31,7 +31,7 @@ checkout or release artifact.
 
 ## Implemented release safeguards
 
-- A manual native workflow can build self-contained 1.5.1 internal desktop
+- A manual native workflow can build self-contained 1.5.2 internal desktop
   packages for macOS arm64 (DMG/ZIP), Windows x64 (NSIS/ZIP), and Ubuntu
   24.04/glibc x64 (AppImage/tar.gz). Each set carries checksums, a CycloneDX
   SBOM, component inventory, and third-party notices and must pass frozen
@@ -44,7 +44,7 @@ checkout or release artifact.
   one root AgentProcess tree. They persist requirements, idempotent command
   receipts, append-only ledger links, and locally integrity-bound resume points;
   they do not introduce a generic workflow DSL or distributed scheduler.
-- RuntimeStore schema v7 is the only store format accepted by ordinary 1.5.1
+- RuntimeStore schema v7 is the only store format accepted by ordinary 1.5.2
   startup. A canonical v6 store has one explicit offline, digest-bound migration
   path to v7; v5 must first migrate to v6 and v4 must first migrate to v5.
   Runtime startup never migrates a store. Schema v3 remains archive-only under
@@ -416,7 +416,7 @@ checkout or release artifact.
   The profile must validate exact publication/operation convergence, attempt
   terminalization, and zero remaining `preparing` work without materializing
   the historical ID set.
-- The `release-artifacts` CI job is configured to build one canonical 1.5.1
+- The `release-artifacts` CI job is configured to build one canonical 1.5.2
   wheel/source pair, reject extra or non-regular output, and record an exact
   checksum manifest.
   Python 3.11 through 3.14 smoke jobs download and verify that same pair, install
@@ -456,7 +456,7 @@ endpoint to read a policy and CSV, compute a report, emit `human_output`, and
 exit. No provenance-bearing report for that run is checked in with the source
 revision, model/profile identity, redacted configuration, environment, and raw
 test outcome needed to reproduce or compare it. It is therefore an unarchived
-observation, not Agent libOS 1.5.1 release evidence, and supports no call-count,
+observation, not Agent libOS 1.5.2 release evidence, and supports no call-count,
 token-count, approval-count, latency, or serial-versus-parallel claim. Promote a
 future rerun only after using a documented opt-in real-model gate and preserving
 its reproducible report outside this status summary.
@@ -495,7 +495,7 @@ its reproducible report outside this status summary.
   non-bare workspace repository and system Git 2.26 or newer; unavailable Git
   fails individual calls without preventing Runtime startup. Host-configured
   remotes are the only first-class Git network exception. There is no Git CLI,
-  GUI/HTTP surface, or real GitHub/GitLab API integration in 1.5.1.
+  GUI/HTTP surface, or real GitHub/GitLab API integration in 1.5.2.
 
 ## Remaining environment gates and non-blocking debt
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -95,7 +95,7 @@ not contact a package index or inspect remote Git references. It also verifies
 that every tracked ordinary source file belongs to the exact sdist
 include/exclude partition; an unclassified top-level file blocks the build
 until a maintainer makes an explicit inclusion decision. For this release
-line it additionally pins the exact target `1.5.1`; a future release must
+line it additionally pins the exact target `1.5.2`; a future release must
 intentionally update that target and its regression contract rather than
 passing merely because stale identifiers agree with one another. Immediately
 before publication authorization, the human owner must re-check the complete
@@ -265,7 +265,7 @@ other cells marked as environment gates are not made true by deterministic CI.
 If a release claim includes one, obtain and bind its documented clean-source
 receipt before authorization.
 
-For the 1.5.1 internal desktop candidate, native packaging is a separate
+For the 1.5.2 internal desktop candidate, native packaging is a separate
 manual workflow (`.github/workflows/desktop-internal.yml`). It builds only on
 the three locked native runners, uploads Actions artifacts for 14 days, and has
 read-only repository permission. Its macOS artifact is ad-hoc signed and not
@@ -312,6 +312,22 @@ git show --no-patch --decorate "v${RELEASE_VERSION}"
 TAG_COMMIT="$(git rev-list -n 1 "v${RELEASE_VERSION}")"
 test "$TAG_COMMIT" = "$RELEASE_COMMIT"
 git push origin "v${RELEASE_VERSION}"
+```
+
+The pushed tag is a hard upload gate, not merely an earlier step. The wheel
+and sdist long description pin every repository link to `/blob/v<version>/`,
+so an index upload before that exact tag exists on the public remote publishes
+a package page whose pinned repository links all fail. Before any TestPyPI or production upload,
+verify that the remote tag resolves to the recorded release commit, and stop
+if it does not:
+
+```bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+REMOTE_TAG_COMMIT="$(git ls-remote --tags origin \
+  "refs/tags/v${RELEASE_VERSION}^{}" | cut -f1)"
+test "$REMOTE_TAG_COMMIT" = "$RELEASE_COMMIT"
 ```
 
 For a first publication or packaging change, the owner may upload the same

--- a/docs/runtime_model.md
+++ b/docs/runtime_model.md
@@ -485,9 +485,9 @@ The current built-in image contracts are:
 | `base-agent:v0` | General runtime work and coordination | 5 Skill lifecycle/bootstrap schemas | configured Human write |
 | `coding-agent:v0` | Repository inspection, editing, Git, and verification | 5 Skill lifecycle/bootstrap schemas | configured Human write and workspace read |
 | `maintenance-agent:v0` | Durable repository maintenance with a fixed reproduce/edit/test/Git/checkpoint/delivery contract | 13 narrow direct schemas | configured Human write and workspace read |
-| `research-agent:v0` | Source-backed evidence collection and synthesis across local and Host-registered integrations | 30 narrow direct schemas | configured Human write and workspace read |
-| `analysis-agent:v0` | Reproducible data analysis with explicit quality and verification gates | 23 narrow direct schemas | configured Human write and workspace read |
-| `operator-agent:v0` | Transactional customer/enterprise workflows with read-back-before-replay recovery | 23 narrow direct schemas | configured Human write |
+| `research-agent:v0` | Source-backed evidence collection and synthesis across local and Host-registered integrations | 32 narrow direct schemas | configured Human write and workspace read |
+| `analysis-agent:v0` | Reproducible data analysis with explicit quality and verification gates | 25 narrow direct schemas | configured Human write and workspace read |
+| `operator-agent:v0` | Transactional customer/enterprise workflows with read-back-before-replay recovery | 25 narrow direct schemas | configured Human write |
 | `review-agent:v0` | Evidence-first review; read-only unless repair is explicitly requested | 5 Skill lifecycle/bootstrap schemas | configured Human write and workspace read |
 | `toolmaker-agent:v0` | Import-free Deno/TypeScript JIT proposal, validation, and registration | 5 Skill lifecycle/bootstrap schemas | configured Human write |
 | `context-compressor:v0` | Structured context compaction | `process_exit` only | none |

--- a/docs/semantic_permission_and_dataflow_research.md
+++ b/docs/semantic_permission_and_dataflow_research.md
@@ -1,5 +1,7 @@
 # 基于语义的自动权限审批与数据流识别：前期调研与落地建议
 
+> **HISTORICAL, COMMIT-PINNED PRE-IMPLEMENTATION RESEARCH** (baseline `dd46f1d5ec439f3539605fd41c7b8938971f45a6`, surveyed 2026-08-03).<br>
+> Not a current contract; see [Semantic Approval and Data Identification](semantic_shadow.md) for current semantic capabilities.<br>
 > 调研日期：2026-08-03<br>
 > 仓库基线：`dd46f1d5ec439f3539605fd41c7b8938971f45a6`（调研时工作区存在其他未提交修改）<br>
 > 适用对象：Agent libOS 的运行时、Capability、Human approval、Protected Operation、Object Memory、provider 与审计子系统<br>

--- a/docs/semantic_shadow.md
+++ b/docs/semantic_shadow.md
@@ -27,7 +27,7 @@ normal Capability and Protected Operation path still owns provider dispatch.
 
 ## Release boundary
 
-Agent libOS 1.5.1 implements:
+Agent libOS 1.5.2 implements:
 
 - a strict, Host-authored `semantic_auto_approval` Task Authority ceiling;
 - a deterministic, pure Shadow broker and a closed action/effect ontology;

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -48,7 +48,7 @@ skills/review-helper/
 name: review-helper
 description: Focused code-review workflow helpers.
 license: Apache-2.0
-compatibility: agent-libos==1.5.1
+compatibility: agent-libos==1.5.2
 allowed-tools: read_text_file read_directory
 metadata:
   agent-libos.version: v0
@@ -184,7 +184,10 @@ are enforcement details, not different LLM protocols.
 Activation materializes the full body into the process prompt and records the
 exact package snapshot on the process. Bundled resources are read explicitly
 with `read_skill_resource` from that activation snapshot, so later registry
-replacement affects only new registered-Skill activations.
+replacement affects only new registered-Skill activations. Serving resource
+reads from the snapshot rather than the registration path prevents a Skill
+from keeping ambient read authority to the workspace path where it was
+registered.
 
 The model-facing lifecycle tools use distinct outer envelopes: discovery
 returns its `skills` page and paging metadata directly, while successful
@@ -216,9 +219,6 @@ the already loaded immutable snapshot. A path retained from trusted package
 instructions or prior authorized evidence can therefore be read, including an
 otherwise omitted JIT-contract resource. The tool does not list paths, and
 callers must not guess or probe hidden filenames.
-
-This prevents a Skill from keeping ambient read authority to the workspace path
-where it was registered.
 
 ## LibOS Extensions
 
@@ -499,7 +499,7 @@ are rejected before a result set can become unbounded.
 The workspace includes `skills/swe-agent`, named and registerable as
 `swe-agent`. It reproduces the useful SWE-Agent Agent Computer Interface shape
 inside Agent libOS. The shipped package pins `compatibility` to
-`agent-libos==1.5.1`: its JIT manifest uses extension fields from this release,
+`agent-libos==1.5.2`: its JIT manifest uses extension fields from this release,
 so older parsers must not be promised compatibility merely because the
 frontmatter itself can be read. This exact pin is a publisher/Host-facing
 declaration, not a Runtime-enforced version gate.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,6 +1,6 @@
 # Runtime Storage
 
-Agent libOS 1.5.1 stores durable runtime state through a `UnitOfWork` composed of
+Agent libOS 1.5.2 stores durable runtime state through a `UnitOfWork` composed of
 explicit domain boundaries, including `ProcessRepository`,
 `ResourceRepository`, `RuntimePublicationRepository`,
 `SnapshotCheckpointRepository`, `RuntimeModuleRepository`,
@@ -126,11 +126,11 @@ this repository has a connection pool or concurrent per-Runtime transactions.
 
 ## Strict store schema v7
 
-Fresh databases created by Agent libOS 1.5.1 use store schema v7 and create a
+Fresh databases created by Agent libOS 1.5.2 use store schema v7 and create a
 `runtime_schema` table with one marker row; the canonical DDL constrains its
 `singleton` value to `1`. Opening an existing store requires the row selected
 by `singleton = 1` to contain schema version `7`. Product version and store
-schema version are independent identifiers: `1.5.1` is the current product
+schema version are independent identifiers: `1.5.2` is the current product
 release, while `7` is the persisted schema contract. Both backends apply
 the same acceptance rules, with one backend-specific initial probe order:
 
@@ -287,7 +287,7 @@ in order.
 There are no automatic migrations, backfills, read-only compatibility modes,
 or dual runtime schema paths. A v3
 database remains archive-only and must be opened with Agent libOS 1.0.1.
-Agent libOS 1.5.1 raises `UnsupportedStoreVersion` during ordinary Runtime
+Agent libOS 1.5.2 raises `UnsupportedStoreVersion` during ordinary Runtime
 preflight, before initialization, index creation, seed insertion, recovery,
 audit, or any other write. The same zero-write rule applies to v4/v5 before the
 matching offline migrator runs, older/unversioned stores, and malformed v7 stores.
@@ -456,10 +456,15 @@ The v5-to-v6 command is an offline administrative surface and is never imported
 or invoked by ordinary Runtime startup:
 
 ```bash
-uv run agent-libos --db <target> store migrate --to 6 --dry-run
+uv run agent-libos --db <target> store migrate --to 6 --dry-run \
+  --sqlite-backup <verified-v5-backup>
 uv run agent-libos --db <target> store migrate --to 6 --apply \
-  --expected-plan-sha256 <digest> <backup-confirmation-option>
+  --expected-plan-sha256 <digest> \
+  --sqlite-backup <verified-v5-backup>
 ```
+
+For PostgreSQL, omit the SQLite backup option and pass
+`--postgres-snapshot-confirmed` on apply.
 
 It uses the same safety protocol as the legacy migration below: stop all
 writers, establish an independent recovery point, validate the complete
@@ -536,8 +541,8 @@ Planning an already-v5/newer or pre-v4 store is not an idempotent “success”:
 planning accepts only an exact canonical v4 source. The narrower exception is
 an apply retry with the same schema-v2 plan and recovery evidence after an
 uncertain commit; an exact v5 migration result is reported as
-`already_applied=true`. See [CLI Reference](cli.md#offline-store-migration) for
-concrete commands.
+`already_applied=true`. See [the CLI guide](cli.md#offline-store-migration)
+for concrete commands.
 
 On POSIX, SQLite apply additionally requires both source and independent backup
 to be current-user-owned, single-link regular files with exact mode `0600`.
@@ -1036,7 +1041,7 @@ Before either backend is backed up:
    not proceed from a recovery-required or incomplete shutdown result.
 4. Record the Agent libOS product version, backend configuration, and the value
    of `runtime_schema.schema_version`. For this release the expected pair is
-   product `1.5.1`, store schema `7`.
+   product `1.5.2`, store schema `7`.
 5. Prepare an owner-only backup directory and run the dump-producing command
    under `umask 077`. Before accepting either backend's archive, verify it is a
    regular, current-user-owned, single-link file with mode `0600`.
@@ -1219,7 +1224,7 @@ persistent target. Do not edit capability, trust, label, decision, or evidence
 rows directly; supported mutations must publish their coupled generation and
 audit/event evidence.
 
-See [Configuration Reference](configuration.md) for library and product
-configuration precedence, [CLI Reference](cli.md) for backend selection, and
+See [the configuration guide](configuration.md) for library and product
+configuration precedence, [the CLI guide](cli.md) for backend selection, and
 [Architecture](architecture.md) for the authority, evidence, primitive, and
 Runtime dependency boundaries.

--- a/docs/task_authority_manifest.md
+++ b/docs/task_authority_manifest.md
@@ -5,6 +5,8 @@
 and a real user, workflow controller, or enterprise policy deciding what this
 particular task may receive.
 
+## Launch contract
+
 `runtime.launch_authority_mode` is fixed to `manifest_required`. Image
 `required_capabilities` are copied into the durable manifest as requirements
 for comparison and Explain output, but they are never granted. Only
@@ -44,6 +46,8 @@ ceilings. A fork derived from an implicit source records an empty model-request
 contract, so copied Host authority does not silently become requestable
 authority.
 
+## Implicit, explicit, and derived manifests
+
 Every launch receives a durable manifest record. When the Host does not supply
 an explicit template, the implicit record contains any capability specs the
 Host supplied through the launch `capabilities` argument; it is empty only when
@@ -68,6 +72,8 @@ authorized/requestable space, extend the parent expiry, or widen a concrete or
 deny-all effect ceiling to unrestricted `null` (or to patterns outside the
 parent's ceiling).
 
+## Model permission requests
+
 Model permission requests are checked against the manifest before a Human
 request is created. `approval_policy.requestable_capabilities` declares
 authority that may be requested but is not granted at launch; a Human decision
@@ -81,6 +87,8 @@ permission-request ceiling, never in the active Capability table. This lets the
 model plan one coherent request before an effect instead of learning the scope
 through a denied probe; the runtime remains the authority and rejects every
 out-of-ceiling request regardless of prompt behavior.
+
+## The bundled GUI as Host author
 
 The bundled GUI is one such Host author. Its visible task-access controls create
 an explicit manifest instead of inferring grants from the selected image. Every
@@ -97,6 +105,8 @@ other non-denied commands still require exact per-use Human approval. Both
 opt-ins are disabled by default, and requests outside the selected ceilings are
 rejected before a Human prompt.
 
+## Permitted provider effects
+
 `permitted_effects` is an additional provider-boundary ceiling with exact
 entries or terminal wildcards such as `jsonrpc.*`. Omitting the field or using
 JSON `null` preserves capability-only effect gating for compatibility. An
@@ -109,6 +119,8 @@ That deny-all ceiling also covers runtime-mediated LLM and Human provider
 effects owned by the process. The explicit `"*"` entry permits every current
 and future effect class and should be used only when that deliberately broad
 ceiling is intended.
+
+## Typed Git effects
 
 Typed Git defines five effect families: `git.read`, `git.mutate`, `git.fetch`,
 `git.push`, and `git.pull_request`. When a concrete effect ceiling is used, it
@@ -125,6 +137,8 @@ any filesystem paths, and the selected remote/PR resources. Mandatory
 destructive-operation approval remains necessary even when the effect family is
 within the manifest ceiling.
 
+## Durable effect-policy envelope
+
 The durable effect-policy envelope is schema version 2 so unrestricted `null`
 and deny-all `[]` cannot collapse during persistence. Legacy version 1 rows are
 upcast on read: their empty list retains its historical unrestricted meaning,
@@ -132,6 +146,8 @@ while every newly written manifest uses the tagged version 2 representation.
 Derived manifests inherit an omitted parent value. An unrestricted parent may
 be narrowed to any list, including deny-all; a concrete or deny-all parent
 cannot be widened back to unrestricted.
+
+## Per-use approval binding
 
 Per-use external-operation approval preallocates the eventual external
 `effect_id` and binds it with the canonical argument hash and target state

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -427,10 +427,12 @@ and only a bounded canonical Host digest can create ingress evidence. The
 generic digest accepts only exact `None`, `bool`, `int`, finite `float`, `str`,
 `bytes`, and `bytearray` values; `StrEnum`; exact `list`/`tuple`; exact `dict`
 with exact string keys; and allowlisted Host dataclasses under a 4,096-node/256
-KiB ceiling. Filesystem, Shell, Git, JSON-RPC, MCP, and LLM are the six core
-provider domains that may use the 500,000-node/64 MiB incremental path; that
-path accepts only exact built-in values, Host-owned module-bound string-valued
-enums, and Host-bound allowlisted dataclasses. The allowlisted `LLMCompletion`
+KiB ceiling. The six provider contract namespaces (Filesystem, Shell, Git, JSON-RPC, MCP, and LLM; `primitive.filesystem.*` through `primitive.llm.*`) may use the 500,000-node/64 MiB incremental path;
+that path accepts only exact built-in values, Host-owned module-bound
+string-valued enums, and Host-bound allowlisted dataclasses. These contract
+namespaces are distinct from the semantic assessment `domain` filter values
+(`filesystem`, `shell`, `git`, `jsonrpc`, `mcp`, `runtime`, `unknown`). The
+allowlisted `LLMCompletion`
 binds only normalized Runtime-consumed fields; raw provider objects, hidden
 reasoning, provider options/trace, and attempt state are outside this identity
 and local-DLP path.

--- a/docs/tools_and_jit.md
+++ b/docs/tools_and_jit.md
@@ -16,12 +16,18 @@ but it does not grant permissions or approve execution.
 
 - [Built-in tools](#built-in-tools)
 - [On-demand Tool Skills](#on-demand-tool-skills)
+- [Context compaction](#context-compaction)
+- [Workflow entry point](#workflow-entry-point)
+- [Object Task entry point](#object-task-entry-point)
 - [Writing Python tools](#writing-python-tools)
 - [JIT tool lifecycle](#jit-tool-lifecycle)
 - [LLM exposure strategy](#llm-exposure-strategy)
 - [TypeScript entry point](#typescript-entry-point)
+- [RPC protocol](#rpc-protocol)
 - [Syscall semantics](#syscall-semantics)
 - [Sandbox rules](#sandbox-rules)
+- [Observability limits](#observability-limits)
+- [Deferred lifecycle](#deferred-lifecycle)
 - Return to the [documentation home](index.md).
 
 ## Built-In Tools
@@ -58,9 +64,11 @@ The current built-in tool surface includes tools for:
   worktrees, immutable patch Objects, existing remotes, and repository-local
   simulated pull requests through `Runtime.git`; no arbitrary Git argv or URL.
 - JSON-RPC: list/inspect registered endpoints and call registered methods.
-- MCP: list/inspect registered servers, list manifest-allowed tools, and call
-  registered MCP tools. Modern `server/discover` is intentionally a Host
-  SDK/CLI/GUI operation rather than another model tool or syscall.
+- MCP: list/inspect registered servers, list manifest-allowed tools, call
+  registered MCP tools, and page/read model-visible Manifest v3 Resources
+  through `list_mcp_resources`/`read_mcp_resource`. Modern `server/discover` is
+  intentionally a Host SDK/CLI/GUI operation rather than another model tool or
+  syscall. See [MCP tools and syscalls](mcp.md#tools-and-syscalls).
 - Image registry: load workspace image packages and commit checkpoints into
   checkpoint-derived images.
 - Checkpoint: create, list, inspect, diff, restore, and fork.
@@ -109,9 +117,12 @@ still require `process:<pid>` `admin`.
 
 The catalog gives each of the 101 built-in static tools one intent-focused owner
 across 26 Skills, with at most nine tools per Skill. The owner is available
-through `SkillManager.builtin_skill_for_tool()`. This keeps automatic routing
-deterministic and prevents overlapping Skills from making unload provenance
-ambiguous:
+through `SkillManager.builtin_skill_for_tool()`. These counts are pinned by the
+release install smoke (`len(catalog.list()) == 26`, `len(owned) == 101`) in
+[`test.yml`](../.github/workflows/test.yml); the catalog source is
+[`builtin_catalog.py`](../agent_libos/skills/builtin_catalog.py). This keeps
+automatic routing deterministic and prevents overlapping Skills from making
+unload provenance ambiguous:
 
 | Built-in Skill | Guidance scope |
 | --- | --- |
@@ -626,7 +637,7 @@ The current syscall surface covers existing primitive areas:
 - process cwd/fork/spawn/wait/list/signal/merge/exec/exit/messages,
 - shell run,
 - JSON-RPC list/inspect/call,
-- MCP list/inspect/tools/call,
+- MCP list/inspect/tools/call/resources/resource_read,
 - image list/inspect/load package/commit checkpoint,
 - checkpoint create/list/inspect/diff/restore/fork/replay,
 - Skill discover/inspect/register_path/activate/read_resource/unload.

--- a/experiments/agentdojo/uv.lock
+++ b/experiments/agentdojo/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11, <3.13"
 
 [[package]]
 name = "agent-libos"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "jsonschema" },

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-libos-gui",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-libos-gui",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "lucide-react": "^1.28.0",
         "react": "^19.2.8",

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-libos-gui",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Agent libOS self-contained internal desktop distribution",
   "author": "Agent libOS contributors",
   "private": true,

--- a/plan.md
+++ b/plan.md
@@ -3,7 +3,10 @@
 > **HISTORICAL ROADMAP — NOT A CURRENT CONTRACT.** The dated submission plan
 > previously kept here is retired. It is not the implementation reference and
 > its milestones, deadlines, evaluation counts, and release assumptions do not
-> describe current behavior.
+> describe current behavior. The retired roadmap was last intact at commit
+> `1a267985c09ce9324747b4e14d8e38265a5f46f4` and was replaced by this notice
+> in commit `76ee42df4124bd491b95d88336335fd6a618c97f`; Git history is the
+> source for the full historical text.
 
 This notice remains only to prevent old links from silently resolving to stale
 guidance. For current information, use:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-libos"
-version = "1.5.1"
+version = "1.5.2"
 description = "A minimal Agent libOS runtime with process, object memory, capability, human approval, JIT tool, checkpoint, and audit primitives."
 readme = "README.pypi.md"
 requires-python = ">=3.11,<3.15"
@@ -29,10 +29,10 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/yingqi-z20/Agent-libOS"
-Documentation = "https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/README.md#documentation"
+Documentation = "https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/README.md#documentation"
 Repository = "https://github.com/yingqi-z20/Agent-libOS"
 Issues = "https://github.com/yingqi-z20/Agent-libOS/issues"
-"Release status" = "https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.1/docs/release_status.md"
+"Release status" = "https://github.com/yingqi-z20/Agent-libOS/blob/v1.5.2/docs/release_status.md"
 
 [project.optional-dependencies]
 postgres = [

--- a/scripts/check_desktop_artifacts.py
+++ b/scripts/check_desktop_artifacts.py
@@ -16,7 +16,7 @@ import zipfile
 
 
 ROOT = Path(__file__).resolve().parents[1]
-VERSION = "1.5.1"
+VERSION = "1.5.2"
 CHANNEL = "internal-unsigned"
 APP_ID = "io.agentlibos.desktop"
 MAX_ARCHIVE_FILES = 50_000

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -23,7 +23,7 @@ from packaging.utils import canonicalize_name
 ROOT = Path(__file__).resolve().parents[1]
 PROJECT_NAME = "agent-libos"
 ARCHIVE_NAME = "agent_libos"
-RELEASE_TARGET_VERSION = "1.5.1"
+RELEASE_TARGET_VERSION = "1.5.2"
 REPOSITORY_URL = "https://github.com/yingqi-z20/Agent-libOS"
 CORE_REQUIREMENTS = (
     "jsonschema<5,>=4.25.0",

--- a/scripts/generate_cli_reference.py
+++ b/scripts/generate_cli_reference.py
@@ -19,9 +19,13 @@ This is the exhaustive command and argument inventory for the checked-in
 use the [CLI Guide](cli.md). Defaults shown here are parser defaults; effective
 Runtime settings may additionally come from `DEFAULT_CONFIG`, `config.yaml`, or
 an explicit `--config` overlay as described in the
-[Configuration Guide](configuration.md). Usage wrapping and metavars are
-normalized across supported Python versions; every accepted option alias is
-listed in the Arguments tables.
+[Configuration Guide](configuration.md). For flags that store a constant
+(including inverse-named flags such as `--optional` and `--flag/--no-flag`
+pairs sharing one destination), the Default column shows `name=value`: the
+parser destination the flag writes and that destination's effective value when
+the flag is absent; passing the flag stores the flag's constant instead.
+Usage wrapping and metavars are normalized across supported Python versions;
+every accepted option alias is listed in the Arguments tables.
 """
 
 
@@ -51,9 +55,21 @@ def _required(action: argparse.Action) -> bool:
     return action.nargs not in {"?", "*"}
 
 
-def _default(action: argparse.Action) -> str:
+def _effective_default(parser: argparse.ArgumentParser, dest: str) -> object:
+    # Mirror argparse namespace initialization: the first action registered for
+    # a dest whose default is not SUPPRESS supplies the effective default.
+    for action in parser._actions:
+        if action.dest == dest and action.default is not argparse.SUPPRESS:
+            return action.default
+    return parser._defaults.get(dest)
+
+
+def _default(action: argparse.Action, parser: argparse.ArgumentParser) -> str:
     if action.default is argparse.SUPPRESS:
         return "—"
+    if isinstance(action, argparse._StoreConstAction) and action.option_strings:
+        effective = _effective_default(parser, action.dest)
+        return _code(f"{action.dest}={effective!r}")
     return _code(repr(action.default))
 
 
@@ -225,7 +241,7 @@ def _render_parser(parser: argparse.ArgumentParser) -> list[str]:
                     (
                         _code(syntax),
                         "yes" if _required(action) else "no",
-                        _default(action),
+                        _default(action, parser),
                         _markdown_text(action.help),
                     )
                 )

--- a/scripts/generate_cli_reference.py
+++ b/scripts/generate_cli_reference.py
@@ -67,7 +67,10 @@ def _effective_default(parser: argparse.ArgumentParser, dest: str) -> object:
 def _default(action: argparse.Action, parser: argparse.ArgumentParser) -> str:
     if action.default is argparse.SUPPRESS:
         return "—"
-    if isinstance(action, argparse._StoreConstAction) and action.option_strings:
+    if isinstance(
+        action,
+        (argparse._StoreConstAction, argparse.BooleanOptionalAction),
+    ) and action.option_strings:
         effective = _effective_default(parser, action.dest)
         return _code(f"{action.dest}={effective!r}")
     return _code(repr(action.default))

--- a/scripts/generate_pypi_readme.py
+++ b/scripts/generate_pypi_readme.py
@@ -17,7 +17,9 @@ _GENERATED_HEADER = (
 )
 _MARKDOWN_LINK = re.compile(r"(?P<prefix>!?\[[^\]]*\]\()(?P<target>[^)]+)(?P<suffix>\))")
 _FINAL_VERSION = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\Z")
-_PROJECT_CLONE = re.compile(r"git clone " + re.escape(REPOSITORY_URL) + r"(?:\.git)?")
+_PROJECT_CLONE = re.compile(
+    r"git clone " + re.escape(REPOSITORY_URL) + r"(?:\.git)?(?=\s|\Z)"
+)
 
 
 def _project_version(root: Path) -> str:

--- a/scripts/generate_pypi_readme.py
+++ b/scripts/generate_pypi_readme.py
@@ -17,6 +17,7 @@ _GENERATED_HEADER = (
 )
 _MARKDOWN_LINK = re.compile(r"(?P<prefix>!?\[[^\]]*\]\()(?P<target>[^)]+)(?P<suffix>\))")
 _FINAL_VERSION = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\Z")
+_PROJECT_CLONE = re.compile(r"git clone " + re.escape(REPOSITORY_URL) + r"(?:\.git)?")
 
 
 def _project_version(root: Path) -> str:
@@ -65,6 +66,15 @@ def render_pypi_readme(source: str, *, version: str) -> str:
         return f'{match.group("prefix")}{rewritten}{title}{match.group("suffix")}'
 
     rendered = _GENERATED_HEADER + _MARKDOWN_LINK.sub(replace, source)
+
+    def pin_clone(match: re.Match[str]) -> str:
+        # The package-index README must reproduce against the immutable release
+        # tag, so a bare `git clone <repo>` is pinned to `--branch v<version>`.
+        return match.group(0).replace("git clone ", f"git clone --branch v{version} ", 1)
+
+    rendered = _PROJECT_CLONE.sub(pin_clone, rendered)
+    if _PROJECT_CLONE.search(rendered):
+        raise ValueError("generated PyPI README contains an unpinned project git clone")
     mutable_prefix = f"{REPOSITORY_URL}/blob/main/"
     if mutable_prefix in rendered:
         raise ValueError("generated PyPI README contains a mutable main-branch link")

--- a/scripts/smoke_mcp_installed_mrtr_tasks.py
+++ b/scripts/smoke_mcp_installed_mrtr_tasks.py
@@ -430,10 +430,10 @@ def _grant_initial_authority(runtime: Runtime, pid: str) -> None:
         )
 
 
-def _assert_private_values_absent(root: Path) -> None:
+def _assert_private_values_absent(store_root: Path) -> None:
     store_bytes = b"".join(
         path.read_bytes()
-        for path in root.glob("durable.sqlite*")
+        for path in store_root.glob("durable.sqlite*")
         if path.is_file()
     )
     for value in _PRIVATE_VALUES:
@@ -569,9 +569,17 @@ def _installed_smoke() -> dict[str, Any]:
             f"environment: module={installed_module} prefix={installed_prefix}"
         )
 
-    with tempfile.TemporaryDirectory(prefix="agent-libos-installed-mrtr-") as root:
-        root_path = Path(root)
-        database = root_path / "durable.sqlite"
+    with (
+        tempfile.TemporaryDirectory(
+            prefix="agent-libos-installed-mrtr-workspace-"
+        ) as workspace_root,
+        tempfile.TemporaryDirectory(
+            prefix="agent-libos-installed-mrtr-store-"
+        ) as store_root,
+    ):
+        workspace_path = Path(workspace_root)
+        store_path = Path(store_root)
+        database = store_path / "durable.sqlite"
         broker = InMemoryMcpCredentialBroker()
         task_created_at: dict[str, str] = {}
         initial_provider = _InitialProvider(task_created_at)
@@ -588,7 +596,7 @@ def _installed_smoke() -> dict[str, Any]:
         first = Runtime.open(
             database,
             substrate=_substrate(
-                root_path,
+                workspace_path,
                 broker,
                 initial_provider,
                 continuation_provider,
@@ -655,11 +663,11 @@ def _installed_smoke() -> dict[str, Any]:
         finally:
             first.close()
 
-        _assert_private_values_absent(root_path)
+        _assert_private_values_absent(store_path)
         reopened = Runtime.open(
             database,
             substrate=_substrate(
-                root_path,
+                workspace_path,
                 broker,
                 initial_provider,
                 continuation_provider,
@@ -693,7 +701,7 @@ def _installed_smoke() -> dict[str, Any]:
         finally:
             reopened.close()
             broker.close()
-        _assert_private_values_absent(root_path)
+        _assert_private_values_absent(store_path)
         return {
             "protocol_revision": "2026-07-28",
             "initial_tool_calls": len(initial_provider.calls),

--- a/scripts/verify_desktop_installers.py
+++ b/scripts/verify_desktop_installers.py
@@ -19,7 +19,7 @@ except ModuleNotFoundError:  # imported as scripts.verify_desktop_installers
     from scripts.smoke_desktop_bundle import _electron_smoke
 
 
-VERSION = "1.5.1"
+VERSION = "1.5.2"
 
 
 def _single(paths: list[Path], label: str) -> Path:

--- a/skills/swe-agent/SKILL.md
+++ b/skills/swe-agent/SKILL.md
@@ -2,7 +2,7 @@
 name: swe-agent
 description: SWE-Agent inspired coding workflow for fixing, reviewing, and improving software repositories through a compact agent-computer interface.
 license: Apache-2.0
-compatibility: agent-libos==1.5.1
+compatibility: agent-libos==1.5.2
 allowed-tools: read_directory read_text_file write_text_file write_directory run_shell_command get_working_directory set_working_directory parse_pytest_log create_checkpoint diff_checkpoint create_memory_object append_memory_object read_memory_object create_object_from_file write_object_to_file request_permission human_output process_exit
 metadata:
   agent-libos.version: v0

--- a/tests/providers/test_mcp_v2_adapter.py
+++ b/tests/providers/test_mcp_v2_adapter.py
@@ -243,7 +243,7 @@ def test_governed_v3_request_ids_do_not_repeat_across_sdk_sessions() -> None:
         metadata = discover.params["_meta"]
         assert metadata["io.modelcontextprotocol/clientInfo"] == {
             "name": "agent-libos",
-            "version": "1.5.1",
+            "version": "1.5.2",
         }
         assert metadata["io.modelcontextprotocol/clientCapabilities"][
             "elicitation"

--- a/tests/security/test_filesystem_path_identity.py
+++ b/tests/security/test_filesystem_path_identity.py
@@ -862,11 +862,31 @@ def test_windows_sink_rejects_case_rename_after_authorization(
     authorized = provider.resolve("victim.TXT")
     assert authorized.relative == "Victim.txt"
 
-    with pytest.raises(CapabilityDenied, match="changed during validation"):
+    with pytest.raises(
+        CapabilityDenied,
+        match="changed while its parent was guarded",
+    ):
         provider.read_bytes(authorized)
 
     assert provider.renamed is True
-    assert (root / "VICTIM.TXT").read_text(encoding="utf-8") == "protected"
+    assert [path.name for path in root.iterdir()] == ["Victim.txt"]
+    assert (root / "Victim.txt").read_text(encoding="utf-8") == "protected"
+
+    pre_entry_root = tmp_path / "pre-entry-case-workspace"
+    pre_entry_root.mkdir()
+    pre_entry_target = pre_entry_root / "Victim.txt"
+    pre_entry_target.write_text("protected", encoding="utf-8")
+    pre_entry_provider = LocalFilesystemProvider(pre_entry_root)
+    pre_entry_authorized = pre_entry_provider.resolve("Victim.txt")
+    intermediate = pre_entry_target.with_name("rename-intermediate.tmp")
+    pre_entry_target.rename(intermediate)
+    intermediate.rename(pre_entry_target.with_name("VICTIM.TXT"))
+
+    with pytest.raises(CapabilityDenied, match="changed during validation"):
+        pre_entry_provider.read_bytes(pre_entry_authorized)
+
+    assert [path.name for path in pre_entry_root.iterdir()] == ["VICTIM.TXT"]
+    assert (pre_entry_root / "VICTIM.TXT").read_text(encoding="utf-8") == "protected"
 
 
 @pytest.mark.platform_windows
@@ -896,12 +916,38 @@ def test_windows_read_rejects_same_spelling_file_id_rebind(tmp_path: Path) -> No
     provider = RebindBeforeOpenProvider(root)
     authorized = provider.resolve("Victim.txt")
 
-    with pytest.raises(CapabilityDenied):
+    with pytest.raises(
+        CapabilityDenied,
+        match="changed while its parent was guarded",
+    ):
         provider.read_bytes(authorized)
 
     assert provider.rebound is True
-    assert victim.read_text(encoding="utf-8") == "replacement"
-    assert (root / "original-victim.txt").read_text(encoding="utf-8") == "authorized"
+    assert victim.read_text(encoding="utf-8") == "authorized"
+    assert not (root / "original-victim.txt").exists()
+
+    pre_entry_root = tmp_path / "pre-entry-read-workspace"
+    pre_entry_root.mkdir()
+    pre_entry_victim = pre_entry_root / "Victim.txt"
+    pre_entry_victim.write_text("authorized", encoding="utf-8")
+    pre_entry_provider = LocalFilesystemProvider(pre_entry_root)
+    pre_entry_authorized = pre_entry_provider.resolve("Victim.txt")
+    _windows_replace_file(
+        pre_entry_victim,
+        pre_entry_root / "original-victim.txt",
+        "replacement",
+    )
+
+    with pytest.raises(
+        CapabilityDenied,
+        match="object identity changed after authorization",
+    ):
+        pre_entry_provider.read_bytes(pre_entry_authorized)
+
+    assert pre_entry_victim.read_text(encoding="utf-8") == "replacement"
+    assert (pre_entry_root / "original-victim.txt").read_text(
+        encoding="utf-8"
+    ) == "authorized"
 
 
 @pytest.mark.platform_windows
@@ -931,11 +977,35 @@ def test_windows_state_rejects_same_spelling_file_id_rebind(tmp_path: Path) -> N
     provider = RebindAtStateProvider(root)
     authorized = provider.resolve("state.txt")
 
-    with pytest.raises(CapabilityDenied):
+    with pytest.raises(CapabilityDenied, match="changed before state"):
         provider.state(authorized)
 
-    assert victim.read_text(encoding="utf-8") == "replacement-state"
-    assert (root / "original-state.txt").read_text(encoding="utf-8") == "authorized-state"
+    assert provider.rebound is True
+    assert victim.read_text(encoding="utf-8") == "authorized-state"
+    assert not (root / "original-state.txt").exists()
+
+    pre_entry_root = tmp_path / "pre-entry-state-workspace"
+    pre_entry_root.mkdir()
+    pre_entry_victim = pre_entry_root / "state.txt"
+    pre_entry_victim.write_text("authorized-state", encoding="utf-8")
+    pre_entry_provider = LocalFilesystemProvider(pre_entry_root)
+    pre_entry_authorized = pre_entry_provider.resolve("state.txt")
+    _windows_replace_file(
+        pre_entry_victim,
+        pre_entry_root / "original-state.txt",
+        "replacement-state",
+    )
+
+    with pytest.raises(
+        CapabilityDenied,
+        match="object identity changed after authorization",
+    ):
+        pre_entry_provider.state(pre_entry_authorized)
+
+    assert pre_entry_victim.read_text(encoding="utf-8") == "replacement-state"
+    assert (pre_entry_root / "original-state.txt").read_text(
+        encoding="utf-8"
+    ) == "authorized-state"
 
 
 @pytest.mark.platform_windows
@@ -967,11 +1037,35 @@ def test_windows_delete_file_rejects_same_spelling_file_id_rebind(
     provider = RebindAtDeleteProvider(root)
     authorized = provider.resolve("delete.txt")
 
-    with pytest.raises(CapabilityDenied):
+    with pytest.raises(CapabilityDenied, match="changed before delete_file"):
         provider.delete_file(authorized)
 
-    assert victim.read_text(encoding="utf-8") == "replacement-delete"
-    assert (root / "original-delete.txt").read_text(encoding="utf-8") == "authorized-delete"
+    assert provider.rebound is True
+    assert victim.read_text(encoding="utf-8") == "authorized-delete"
+    assert not (root / "original-delete.txt").exists()
+
+    pre_entry_root = tmp_path / "pre-entry-delete-workspace"
+    pre_entry_root.mkdir()
+    pre_entry_victim = pre_entry_root / "delete.txt"
+    pre_entry_victim.write_text("authorized-delete", encoding="utf-8")
+    pre_entry_provider = LocalFilesystemProvider(pre_entry_root)
+    pre_entry_authorized = pre_entry_provider.resolve("delete.txt")
+    _windows_replace_file(
+        pre_entry_victim,
+        pre_entry_root / "original-delete.txt",
+        "replacement-delete",
+    )
+
+    with pytest.raises(
+        CapabilityDenied,
+        match="object identity changed after authorization",
+    ):
+        pre_entry_provider.delete_file(pre_entry_authorized)
+
+    assert pre_entry_victim.read_text(encoding="utf-8") == "replacement-delete"
+    assert (pre_entry_root / "original-delete.txt").read_text(
+        encoding="utf-8"
+    ) == "authorized-delete"
 
 
 @pytest.mark.platform_windows
@@ -1005,11 +1099,46 @@ def test_windows_recursive_delete_rejects_same_spelling_directory_id_rebind(
     provider = RebindAtRecursiveDeleteProvider(root)
     authorized = provider.resolve("tree")
 
-    with pytest.raises(CapabilityDenied):
+    with pytest.raises(
+        CapabilityDenied,
+        match="changed before delete_directory",
+    ):
         provider.delete_directory(authorized, recursive=True)
 
-    assert (tree / "replacement-marker.txt").read_text(encoding="utf-8") == "replacement"
-    assert (root / "original-tree" / "authorized-marker.txt").read_text(
+    assert provider.rebound is True
+    assert (tree / "authorized-marker.txt").read_text(
+        encoding="utf-8"
+    ) == "authorized"
+    assert not (tree / "replacement-marker.txt").exists()
+    assert not (root / "original-tree").exists()
+
+    pre_entry_root = tmp_path / "pre-entry-tree-workspace"
+    pre_entry_tree = pre_entry_root / "tree"
+    pre_entry_tree.mkdir(parents=True)
+    (pre_entry_tree / "authorized-marker.txt").write_text(
+        "authorized",
+        encoding="utf-8",
+    )
+    pre_entry_provider = LocalFilesystemProvider(pre_entry_root)
+    pre_entry_authorized = pre_entry_provider.resolve("tree")
+    pre_entry_original = pre_entry_root / "original-tree"
+    pre_entry_tree.rename(pre_entry_original)
+    pre_entry_tree.mkdir()
+    (pre_entry_tree / "replacement-marker.txt").write_text(
+        "replacement",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        CapabilityDenied,
+        match="object identity changed after authorization",
+    ):
+        pre_entry_provider.delete_directory(pre_entry_authorized, recursive=True)
+
+    assert (pre_entry_tree / "replacement-marker.txt").read_text(
+        encoding="utf-8"
+    ) == "replacement"
+    assert (pre_entry_original / "authorized-marker.txt").read_text(
         encoding="utf-8"
     ) == "authorized"
 
@@ -1080,11 +1209,35 @@ def test_windows_make_directory_rejects_existing_parent_file_id_rebind(
     provider = RebindParentProvider(root)
     authorized = provider.resolve("parent/child")
 
-    with pytest.raises(CapabilityDenied):
+    with pytest.raises(CapabilityDenied, match="changed before make_directory"):
         provider.make_directory(authorized, parents=True, exist_ok=False)
 
+    assert provider.rebound is True
+    assert parent.is_dir()
     assert not (parent / "child").exists()
-    assert (root / "original-parent").is_dir()
+    assert not (root / "original-parent").exists()
+
+    pre_entry_root = tmp_path / "pre-entry-mkdir-workspace"
+    pre_entry_parent = pre_entry_root / "parent"
+    pre_entry_parent.mkdir(parents=True)
+    pre_entry_provider = LocalFilesystemProvider(pre_entry_root)
+    pre_entry_authorized = pre_entry_provider.resolve("parent/child")
+    pre_entry_original = pre_entry_root / "original-parent"
+    pre_entry_parent.rename(pre_entry_original)
+    pre_entry_parent.mkdir()
+
+    with pytest.raises(
+        CapabilityDenied,
+        match="parent identity changed after authorization",
+    ):
+        pre_entry_provider.make_directory(
+            pre_entry_authorized,
+            parents=True,
+            exist_ok=False,
+        )
+
+    assert not (pre_entry_parent / "child").exists()
+    assert pre_entry_original.is_dir()
 
 
 @pytest.mark.platform_windows
@@ -1113,11 +1266,35 @@ def test_windows_write_rejects_existing_parent_file_id_rebind(
     provider = RebindWriteParentProvider(root)
     authorized = provider.resolve("parent/child.txt")
 
-    with pytest.raises(CapabilityDenied):
+    with pytest.raises(CapabilityDenied, match="changed before write_parent"):
         provider.write_text(authorized, "blocked", "utf-8")
 
+    assert provider.rebound is True
+    assert parent.is_dir()
     assert not (parent / "child.txt").exists()
-    assert (root / "original-write-parent").is_dir()
+    assert not (root / "original-write-parent").exists()
+
+    pre_entry_root = tmp_path / "pre-entry-write-workspace"
+    pre_entry_parent = pre_entry_root / "parent"
+    pre_entry_parent.mkdir(parents=True)
+    pre_entry_provider = LocalFilesystemProvider(pre_entry_root)
+    pre_entry_authorized = pre_entry_provider.resolve("parent/child.txt")
+    pre_entry_original = pre_entry_root / "original-write-parent"
+    pre_entry_parent.rename(pre_entry_original)
+    pre_entry_parent.mkdir()
+
+    with pytest.raises(
+        CapabilityDenied,
+        match="parent identity changed after authorization",
+    ):
+        pre_entry_provider.write_text(
+            pre_entry_authorized,
+            "blocked",
+            "utf-8",
+        )
+
+    assert not (pre_entry_parent / "child.txt").exists()
+    assert pre_entry_original.is_dir()
 
 
 @pytest.mark.platform_windows

--- a/tests/security/test_runtime_store_workspace_isolation.py
+++ b/tests/security/test_runtime_store_workspace_isolation.py
@@ -701,8 +701,14 @@ def test_resolved_user_store_keeps_home_and_secure_directory_frozen(
     try:
         expected_directory = original_home / ".agent-libos" / "runtime"
         assert Path(store.path) == expected_directory / "agent-libos.sqlite"
-        assert stat.S_IMODE(os.stat(original_home / ".agent-libos").st_mode) == 0o700
-        assert stat.S_IMODE(os.stat(expected_directory).st_mode) == 0o700
+        assert (original_home / ".agent-libos").is_dir()
+        assert expected_directory.is_dir()
+        if os.name == "posix":
+            assert (
+                stat.S_IMODE(os.stat(original_home / ".agent-libos").st_mode)
+                == 0o700
+            )
+            assert stat.S_IMODE(os.stat(expected_directory).st_mode) == 0o700
         assert not (changed_home / ".agent-libos").exists()
     finally:
         store.close()

--- a/tests/security/test_semantic_canary_runtime.py
+++ b/tests/security/test_semantic_canary_runtime.py
@@ -64,6 +64,7 @@ _TENANT = "tenant-canary-security"
 _PROFILE_ID = "semantic-canary-security"
 _MODEL = "semantic-canary-model"
 _RULE_ID = "canary-reports-read"
+_REAL_GIT_ASSESSMENT_TIMEOUT_S = 180.0
 
 
 class _SuccessfulSemanticClient:
@@ -379,6 +380,21 @@ def _git_rule(action_id: str) -> SemanticApprovalRule:
         authority_operation=action_id,
         resource="git:workspace",
         rights=(right,),
+    )
+
+
+def _real_git_canary_config(rule: SemanticApprovalRule) -> AgentLibOSConfig:
+    config = _canary_config(auto_approval_rules=(rule,))
+    # Live Git snapshots can exceed the production 30-second assessment window
+    # under loaded Windows xdist workers. These tests exercise exact Git
+    # binding and drift fences, not the deadline fallback.
+    return replace(
+        config,
+        semantic=replace(
+            config.semantic,
+            assessment_timeout_s=_REAL_GIT_ASSESSMENT_TIMEOUT_S,
+            job_lease_s=_REAL_GIT_ASSESSMENT_TIMEOUT_S,
+        ),
     )
 
 
@@ -808,7 +824,7 @@ def test_real_git_canary_exact_request_issues_consumes_and_succeeds(
     client = _SuccessfulSemanticClient()
     runtime = Runtime.open(
         tmp_path / f"{action_id}.sqlite",
-        config=_canary_config(auto_approval_rules=(rule,)),
+        config=_real_git_canary_config(rule),
         substrate=LocalResourceProviderSubstrate(workspace),
         semantic_tenant_bucketer=_tenant_bucket,
     )
@@ -948,7 +964,7 @@ def test_real_git_canary_drift_blocks_before_protected_provider_dispatch(
     rule = _git_rule("git.read")
     runtime = Runtime.open(
         tmp_path / f"git-drift-{drift}.sqlite",
-        config=_canary_config(auto_approval_rules=(rule,)),
+        config=_real_git_canary_config(rule),
         substrate=LocalResourceProviderSubstrate(workspace),
         semantic_tenant_bucketer=_tenant_bucket,
     )

--- a/tests/self_evolution/test_swe_agent_skill.py
+++ b/tests/self_evolution/test_swe_agent_skill.py
@@ -30,7 +30,7 @@ class TestSWEAgentSkill:
     def test_shipped_skill_pins_current_jit_extension_compatibility(self) -> None:
         skill_md = PACKAGE_ROOT.joinpath('SKILL.md').read_text(encoding='utf-8')
 
-        assert 'compatibility: agent-libos==1.5.1\n' in skill_md
+        assert 'compatibility: agent-libos==1.5.2\n' in skill_md
 
     def test_shipped_docs_explain_ripgrep_no_match_status(self) -> None:
         skill_md = PACKAGE_ROOT.joinpath('SKILL.md').read_text(encoding='utf-8')

--- a/tests/unit/test_desktop_distribution.py
+++ b/tests/unit/test_desktop_distribution.py
@@ -24,7 +24,7 @@ def test_desktop_runtime_manifest_locks_exact_internal_toolchain() -> None:
     assert manifest["distribution_channel"] == "internal-unsigned"
     assert manifest["product"] == {
         "name": "Agent libOS",
-        "version": "1.5.1",
+        "version": "1.5.2",
         "app_id": "io.agentlibos.desktop",
     }
     assert manifest["toolchain"] == {
@@ -59,7 +59,7 @@ def test_desktop_build_metadata_and_scripts_use_exact_versions_and_no_publish() 
     config = (ROOT / "gui" / "electron-builder.yml").read_text(encoding="utf-8")
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert package["version"] == "1.5.1"
+    assert package["version"] == "1.5.2"
     assert package["devDependencies"]["electron"] == "43.2.0"
     assert package["devDependencies"]["electron-builder"] == "26.15.3"
     assert lock["packages"]["node_modules/electron"]["version"] == "43.2.0"
@@ -96,17 +96,17 @@ def test_internal_desktop_workflow_is_manual_native_and_artifact_only() -> None:
 
 
 def test_desktop_release_names_are_exact_for_three_native_targets() -> None:
-    assert finalizer._package_names("1.5.1", "darwin-arm64") == (
-        "Agent-libOS-1.5.1-macos-arm64.dmg",
-        "Agent-libOS-1.5.1-macos-arm64.zip",
+    assert finalizer._package_names("1.5.2", "darwin-arm64") == (
+        "Agent-libOS-1.5.2-macos-arm64.dmg",
+        "Agent-libOS-1.5.2-macos-arm64.zip",
     )
-    assert finalizer._package_names("1.5.1", "win32-x64") == (
-        "Agent-libOS-Setup-1.5.1-windows-x64.exe",
-        "Agent-libOS-1.5.1-windows-x64.zip",
+    assert finalizer._package_names("1.5.2", "win32-x64") == (
+        "Agent-libOS-Setup-1.5.2-windows-x64.exe",
+        "Agent-libOS-1.5.2-windows-x64.zip",
     )
-    assert finalizer._package_names("1.5.1", "linux-x64") == (
-        "Agent-libOS-1.5.1-linux-x64.AppImage",
-        "Agent-libOS-1.5.1-linux-x64.tar.gz",
+    assert finalizer._package_names("1.5.2", "linux-x64") == (
+        "Agent-libOS-1.5.2-linux-x64.AppImage",
+        "Agent-libOS-1.5.2-linux-x64.tar.gz",
     )
 
 
@@ -133,15 +133,15 @@ def test_desktop_helpers_reject_broad_output_and_unsafe_archive_paths(tmp_path: 
 
 
 def test_editable_checkout_receipt_is_removed_from_frozen_metadata(tmp_path: Path) -> None:
-    metadata = tmp_path / "_internal" / "agent_libos-1.5.1.dist-info"
+    metadata = tmp_path / "_internal" / "agent_libos-1.5.2.dist-info"
     metadata.mkdir(parents=True)
     (metadata / "direct_url.json").write_text(
         '{"url":"file:///private/checkout","dir_info":{"editable":true}}',
         encoding="utf-8",
     )
     (metadata / "RECORD").write_text(
-        "agent_libos-1.5.1.dist-info/direct_url.json,sha256=abc,1\n"
-        "agent_libos-1.5.1.dist-info/METADATA,sha256=def,2\n",
+        "agent_libos-1.5.2.dist-info/direct_url.json,sha256=abc,1\n"
+        "agent_libos-1.5.2.dist-info/METADATA,sha256=def,2\n",
         encoding="utf-8",
     )
 
@@ -155,8 +155,8 @@ def test_desktop_finalizer_removes_unpublished_update_and_debug_metadata(
     tmp_path: Path,
 ) -> None:
     for name in (
-        "Agent-libOS-1.5.1-macos-arm64.zip.blockmap",
-        "Agent-libOS-1.5.1-macos-arm64.dmg.blockmap",
+        "Agent-libOS-1.5.2-macos-arm64.zip.blockmap",
+        "Agent-libOS-1.5.2-macos-arm64.dmg.blockmap",
         "builder-debug.yml",
         "builder-effective-config.yaml",
     ):
@@ -176,7 +176,7 @@ def test_desktop_sbom_requires_runtime_mcp_keyring_electron_deno_and_python(
     components = [
         {"name": name, "version": version}
         for name, version in {
-            "agent-libos": "1.5.1",
+            "agent-libos": "1.5.2",
             "CPython": "3.11.15",
             "Deno": "2.9.5",
             "electron": "43.2.0",
@@ -190,7 +190,7 @@ def test_desktop_sbom_requires_runtime_mcp_keyring_electron_deno_and_python(
         "metadata": {
             "component": {
                 "name": "Agent libOS",
-                "version": "1.5.1",
+                "version": "1.5.2",
                 "properties": [
                     {
                         "name": "agent-libos:distribution-channel",

--- a/tests/unit/test_generated_documentation.py
+++ b/tests/unit/test_generated_documentation.py
@@ -269,7 +269,10 @@ def test_generated_cli_reference_matches_every_parser_command_and_option() -> No
             )
             if action.default is argparse.SUPPRESS:
                 expected_default = "—"
-            elif isinstance(action, argparse._StoreConstAction) and action.option_strings:
+            elif isinstance(
+                action,
+                (argparse._StoreConstAction, argparse.BooleanOptionalAction),
+            ) and action.option_strings:
                 effective = next(
                     (
                         candidate.default
@@ -304,8 +307,9 @@ def test_generated_cli_reference_matches_every_parser_command_and_option() -> No
 def test_generated_cli_reference_reports_effective_defaults_for_inverse_flags() -> None:
     # Regression: store_false flags such as `task-run follow-up --optional`
     # and shared-dest mutually exclusive pairs such as `exec --run/--no-run`
-    # must report the destination they write and its effective parser default,
-    # not the raw per-action default with inverted polarity.
+    # and BooleanOptionalAction pairs must report the destination they write
+    # and its effective parser default, not the raw per-action default with
+    # inverted polarity.
     rendered = render_cli_reference()
     follow_up = rendered.split("## `agent-libos task-run follow-up`", 1)[1].split(
         "\n## ", 1
@@ -324,6 +328,23 @@ def test_generated_cli_reference_reports_effective_defaults_for_inverse_flags() 
     )
     assert "| `run=False` |" in run_row
     assert "| `run=False` |" in no_run_row
+
+    preserve_memory_row = next(
+        line
+        for line in exec_section.splitlines()
+        if line.startswith("| `--preserve-memory, --no-preserve-memory`")
+    )
+    assert "| `preserve_memory=True` |" in preserve_memory_row
+
+    grant_section = rendered.split("## `agent-libos capabilities grant`", 1)[1].split(
+        "\n## ", 1
+    )[0]
+    revocable_row = next(
+        line
+        for line in grant_section.splitlines()
+        if line.startswith("| `--revocable, --no-revocable`")
+    )
+    assert "| `revocable=True` |" in revocable_row
 
 
 def test_generated_cli_index_matches_unique_top_level_sections() -> None:
@@ -592,9 +613,17 @@ def test_pypi_readme_pins_clone_with_target_directory() -> None:
     )
 
 
-def test_pypi_readme_does_not_pin_foreign_clone() -> None:
-    source = "git clone https://github.com/other/repo.git\n"
+@pytest.mark.parametrize(
+    "repository",
+    (
+        "https://github.com/other/repo.git",
+        "https://github.com/yingqi-z20/Agent-libOS-fork.git",
+        "https://github.com/yingqi-z20/Agent-libOS.git-mirror",
+    ),
+)
+def test_pypi_readme_does_not_pin_foreign_clone(repository: str) -> None:
+    source = f"git clone {repository}\n"
     rendered = render_pypi_readme(source, version="1.2.3")
 
-    assert "git clone https://github.com/other/repo.git" in rendered
+    assert f"git clone {repository}" in rendered
     assert "--branch" not in rendered

--- a/tests/unit/test_generated_documentation.py
+++ b/tests/unit/test_generated_documentation.py
@@ -267,13 +267,29 @@ def test_generated_cli_reference_matches_every_parser_command_and_option() -> No
             expected_required = bool(action.required) if action.option_strings else (
                 action.nargs not in {"?", "*"}
             )
-            expected_default = (
-                "—"
-                if action.default is argparse.SUPPRESS
-                else "`"
-                + repr(action.default).replace("|", "\\|").replace("`", "\\`")
-                + "`"
-            )
+            if action.default is argparse.SUPPRESS:
+                expected_default = "—"
+            elif isinstance(action, argparse._StoreConstAction) and action.option_strings:
+                effective = next(
+                    (
+                        candidate.default
+                        for candidate in parser._actions
+                        if candidate.dest == action.dest
+                        and candidate.default is not argparse.SUPPRESS
+                    ),
+                    parser._defaults.get(action.dest),
+                )
+                expected_default = (
+                    "`"
+                    + f"{action.dest}={effective!r}".replace("|", "\\|").replace("`", "\\`")
+                    + "`"
+                )
+            else:
+                expected_default = (
+                    "`"
+                    + repr(action.default).replace("|", "\\|").replace("`", "\\`")
+                    + "`"
+                )
             assert row[1] == ("yes" if expected_required else "no")
             assert row[2] == expected_default
 
@@ -283,6 +299,31 @@ def test_generated_cli_reference_matches_every_parser_command_and_option() -> No
             for command in action.choices:
                 escaped = str(command).replace("|", "\\|").replace("`", "\\`")
                 assert f"| `{escaped}` |" in section
+
+
+def test_generated_cli_reference_reports_effective_defaults_for_inverse_flags() -> None:
+    # Regression: store_false flags such as `task-run follow-up --optional`
+    # and shared-dest mutually exclusive pairs such as `exec --run/--no-run`
+    # must report the destination they write and its effective parser default,
+    # not the raw per-action default with inverted polarity.
+    rendered = render_cli_reference()
+    follow_up = rendered.split("## `agent-libos task-run follow-up`", 1)[1].split(
+        "\n## ", 1
+    )[0]
+    optional_row = next(
+        line for line in follow_up.splitlines() if line.startswith("| `--optional`")
+    )
+    assert "| `required=True` |" in optional_row
+
+    exec_section = rendered.split("## `agent-libos exec`", 1)[1].split("\n## ", 1)[0]
+    run_row = next(
+        line for line in exec_section.splitlines() if line.startswith("| `--run`")
+    )
+    no_run_row = next(
+        line for line in exec_section.splitlines() if line.startswith("| `--no-run`")
+    )
+    assert "| `run=False` |" in run_row
+    assert "| `run=False` |" in no_run_row
 
 
 def test_generated_cli_index_matches_unique_top_level_sections() -> None:
@@ -528,3 +569,32 @@ def test_pypi_readme_rewrites_only_repository_relative_and_mutable_links() -> No
 def test_pypi_readme_rejects_nonportable_repository_links(target: str) -> None:
     with pytest.raises(ValueError, match="portable|safe"):
         render_pypi_readme(f"[bad]({target})\n", version="1.2.3")
+
+
+def test_pypi_readme_pins_quickstart_clone_to_release_tag() -> None:
+    source = "git clone https://github.com/yingqi-z20/Agent-libOS.git\n"
+    rendered = render_pypi_readme(source, version="1.2.3")
+
+    assert (
+        "git clone --branch v1.2.3 https://github.com/yingqi-z20/Agent-libOS.git"
+        in rendered
+    )
+    assert "git clone https://github.com/yingqi-z20/Agent-libOS.git" not in rendered
+
+
+def test_pypi_readme_pins_clone_with_target_directory() -> None:
+    source = "git clone https://github.com/yingqi-z20/Agent-libOS.git agentlibos\n"
+    rendered = render_pypi_readme(source, version="1.2.3")
+
+    assert (
+        "git clone --branch v1.2.3 https://github.com/yingqi-z20/Agent-libOS.git agentlibos"
+        in rendered
+    )
+
+
+def test_pypi_readme_does_not_pin_foreign_clone() -> None:
+    source = "git clone https://github.com/other/repo.git\n"
+    rendered = render_pypi_readme(source, version="1.2.3")
+
+    assert "git clone https://github.com/other/repo.git" in rendered
+    assert "--branch" not in rendered

--- a/tests/unit/test_glossary_version_map.py
+++ b/tests/unit/test_glossary_version_map.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCS = ROOT / "docs"
+
+
+def _version_map_section() -> str:
+    text = (DOCS / "glossary.md").read_text(encoding="utf-8")
+    start = text.find("## Version map")
+    assert start != -1, "docs/glossary.md must keep a '## Version map' section"
+    after = text[start:]
+    nxt = re.search(r"\n## ", after[3:])
+    end = (3 + nxt.start()) if nxt else len(after)
+    return after[:end]
+
+
+def _maintained_docs() -> list[Path]:
+    files = sorted(ROOT.glob("*.md")) + sorted(DOCS.glob("*.md"))
+    # Skip generated artifacts: their content is pinned by generators/tests.
+    skip = {"README.pypi.md", "cli_reference.md", "configuration_reference.md"}
+    return [f for f in files if f.name not in skip]
+
+
+def test_version_map_documents_namespaces_used_by_docs() -> None:
+    """The version map is the contract-mandated disambiguation point
+    (docs/index.md: before interpreting an unqualified v1/v2/v3/v7, consult the
+    version map). It must therefore list the version namespaces the docs actually
+    reference with bare tokens. This ratchets the prompt-layout/prompt-cache
+    namespace and the frozen RuntimeStore schema, GUI snapshot, and public
+    semantic-status projections so a future edit cannot silently drop them."""
+    vm = _version_map_section().lower()
+    assert "prompt" in vm and "cache" in vm  # llm.prompt_layout / prompt-cache v1/v2
+    assert "runtimestore schema" in vm  # persisted SQL store shape (frozen value 7)
+    assert "snapshot" in vm  # GUI snapshot envelope
+    assert "semantic" in vm  # public semantic-status projection (value 3)
+
+
+def test_no_stale_prerelease_schema_tokens_in_docs() -> None:
+    """The RuntimeStore schema is frozen at v7; pre-1.0 product-version tokens
+    such as '0.3' must not survive as schema/visibility qualifiers anywhere in
+    the maintained docs. This ratchets the stale-token fix so a regression
+    (e.g. re-introducing 'the 0.3 schema' or 'required 0.3 visibility state')
+    fails CI rather than shipping as an unmappable version."""
+    stale = re.compile(r"(?<!\d)0\.\d+\s+(?:schema|visibility)", re.IGNORECASE)
+    failures: list[str] = []
+    for doc in _maintained_docs():
+        text = doc.read_text(encoding="utf-8")
+        for match in stale.finditer(text):
+            failures.append(
+                f"{doc.relative_to(ROOT)}: stale pre-release schema/visibility "
+                f"token {match.group()!r}"
+            )
+    assert not failures, "\n".join(failures)

--- a/tests/unit/test_release_contract.py
+++ b/tests/unit/test_release_contract.py
@@ -204,7 +204,7 @@ def _write_test_sdist(
     return target
 
 
-def _write_release_pair(target: Path, *, version: str = "1.5.1") -> tuple[Path, Path]:
+def _write_release_pair(target: Path, *, version: str = "1.5.2") -> tuple[Path, Path]:
     wheel = _write_test_wheel(
         target / f"agent_libos-{version}-py3-none-any.whl",
         version=version,
@@ -217,11 +217,11 @@ def _write_release_pair(target: Path, *, version: str = "1.5.1") -> tuple[Path, 
 
 
 def test_release_version_identifiers_are_aligned() -> None:
-    assert validate_version_alignment(ROOT) == "1.5.1"
+    assert validate_version_alignment(ROOT) == "1.5.2"
 
 
 def test_release_protocol_versions_are_independent_and_default_off() -> None:
-    assert __version__ == "1.5.1"
+    assert __version__ == "1.5.2"
     assert STORE_SCHEMA_VERSION == 7
     assert SEMANTIC_STATUS_SCHEMA_VERSION == 3
     assert DEFAULT_CONFIG.semantic.mode == "off"
@@ -235,7 +235,7 @@ def test_agentdojo_lock_tracks_current_editable_agent_libos_metadata() -> None:
         )
     )
     package = next(item for item in lock["package"] if item["name"] == "agent-libos")
-    assert package["version"] == "1.5.1"
+    assert package["version"] == "1.5.2"
     assert package["source"] == {"editable": "../../"}
     assert {
         (item["specifier"], item["marker"])
@@ -248,7 +248,7 @@ def test_root_lock_resolves_the_reviewed_mcp_sdk_v2_graph() -> None:
     lock = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
     packages = {item["name"]: item for item in lock["package"]}
 
-    assert packages["agent-libos"]["version"] == "1.5.1"
+    assert packages["agent-libos"]["version"] == "1.5.2"
     assert packages["mcp"]["version"] == "2.0.0"
     assert packages["mcp-types"]["version"] == "2.0.0"
     assert {
@@ -828,7 +828,7 @@ def test_release_checksum_manifest_records_and_verifies_exact_artifacts(
 
 def test_release_status_contains_current_version_state_only() -> None:
     text = (ROOT / "docs" / "release_status.md").read_text(encoding="utf-8")
-    assert text.startswith("# Agent libOS 1.5.1 Status\n")
+    assert text.startswith("# Agent libOS 1.5.2 Status\n")
     forbidden = {
         "dirty state": r"\bdirty\b",
         "worktree state": r"\bwork(?:ing)?[ -]?tree\b",
@@ -919,7 +919,7 @@ def test_release_status_bounds_unarchived_evidence_and_volatile_counts() -> None
     text = (ROOT / "docs" / "release_status.md").read_text(encoding="utf-8")
 
     assert "## Unarchived real-LLM observation" in text
-    assert "not Agent libOS 1.5.1 release evidence" in text
+    assert "not Agent libOS 1.5.2 release evidence" in text
     assert "AgentDojo harness is a required CI matrix" in text
     assert "collected pytest nodes" not in text
     assert not re.search(r"selects [\d,]+ tests", text)
@@ -1359,8 +1359,8 @@ def test_canonical_release_docs_cover_artifacts_and_clean_install_readback() -> 
 
     assert "[Development Guide](docs/development.md)" in readme
     assert "[Release Runbook](docs/releasing.md)" in readme
-    assert "dist/agent_libos-1.5.1-py3-none-any.whl" in development
-    assert "dist/agent_libos-1.5.1.tar.gz" in development
+    assert "dist/agent_libos-1.5.2-py3-none-any.whl" in development
+    assert "dist/agent_libos-1.5.2.tar.gz" in development
     assert '"$RELEASE_WHEEL"' in releasing
     assert '"$RELEASE_SDIST"' in releasing
     assert "set(published) != set(canonical)" in releasing
@@ -1384,7 +1384,7 @@ def test_gui_dependency_baseline_is_current_and_lockfile_aligned() -> None:
         (ROOT / "gui" / "package-lock.json").read_text(encoding="utf-8")
     )
 
-    assert package["version"] == "1.5.1"
+    assert package["version"] == "1.5.2"
     assert package["dependencies"] == {
         "lucide-react": "^1.28.0",
         "react": "^19.2.8",
@@ -1414,7 +1414,7 @@ def test_gui_dependency_baseline_is_current_and_lockfile_aligned() -> None:
     }
     assert "overrides" not in package
     locked_root = lockfile["packages"][""]
-    assert locked_root["version"] == "1.5.1"
+    assert locked_root["version"] == "1.5.2"
     assert locked_root["dependencies"] == package["dependencies"]
     assert locked_root["devDependencies"] == package["devDependencies"]
     assert locked_root["engines"] == package["engines"]
@@ -2499,8 +2499,8 @@ def test_release_workflow_preserves_and_clean_installs_validated_artifacts() -> 
         "cancel-in-progress": True,
     }
     assert parsed["env"] == {
-        "RELEASE_WHEEL": "dist/agent_libos-1.5.1-py3-none-any.whl",
-        "RELEASE_SDIST": "dist/agent_libos-1.5.1.tar.gz",
+        "RELEASE_WHEEL": "dist/agent_libos-1.5.2-py3-none-any.whl",
+        "RELEASE_SDIST": "dist/agent_libos-1.5.2.tar.gz",
         "RELEASE_CHECKSUMS": "dist/SHA256SUMS",
     }
     release_steps = release_job["steps"]

--- a/tests/unit/test_release_contract.py
+++ b/tests/unit/test_release_contract.py
@@ -1203,15 +1203,19 @@ def test_mcp_durable_artifact_smoke_uses_installed_runtime_store_and_cli() -> No
         "first = Runtime.open(",
         "reopened = Runtime.open(",
         "first.mcp.call_tool(",
+        'prefix="agent-libos-installed-mrtr-workspace-"',
+        'prefix="agent-libos-installed-mrtr-store-"',
+        'database = store_path / "durable.sqlite"',
         '"continuations",',
         '"remote-tasks",',
-        "_assert_private_values_absent(root_path)",
+        "_assert_private_values_absent(store_path)",
         "if len(initial_provider.calls) != 4",
         "if continuation_provider.calls != 1",
         "tasks_provider.get_calls != 3",
         '"runtime-v3-durable-cli": _installed_smoke()',
     ):
         assert required in smoke
+    assert 'database = workspace_path / "durable.sqlite"' not in smoke
     assert "pytest.skip" not in smoke
 
 

--- a/tests/unit/test_release_status_regressions.py
+++ b/tests/unit/test_release_status_regressions.py
@@ -46,7 +46,7 @@ def test_mcp_docs_lock_manifest_client_info_identities() -> None:
         in normalized
     )
     assert (
-        "| v3 exact `2026-07-28` | `agent-libos` | `1.5.1` |"
+        "| v3 exact `2026-07-28` | `agent-libos` | `1.5.2` |"
         in normalized
     )
     assert "v1 and v2 values are frozen compatibility identities" in normalized

--- a/tests/unit/test_release_version_syntax.py
+++ b/tests/unit/test_release_version_syntax.py
@@ -114,7 +114,7 @@ def test_release_version_syntax_accepts_final_numeric_ascii_triplet(
 def test_release_version_accepts_only_the_current_target(tmp_path: Path) -> None:
     _write_aligned_release_metadata(tmp_path, RELEASE_TARGET_VERSION)
 
-    assert validate_version_alignment(tmp_path) == "1.5.1"
+    assert validate_version_alignment(tmp_path) == "1.5.2"
 
 
 @pytest.mark.parametrize("version", ["0.0.0", "1.4.2", "2.0.0", "10.20.30"])
@@ -124,7 +124,7 @@ def test_release_version_rejects_aligned_non_target_version(
 ) -> None:
     _write_aligned_release_metadata(tmp_path, version)
 
-    with pytest.raises(ValueError, match="target version must be exactly 1.5.1"):
+    with pytest.raises(ValueError, match="target version must be exactly 1.5.2"):
         validate_version_alignment(tmp_path)
 
 
@@ -157,56 +157,56 @@ def test_release_version_rejects_non_final_or_non_ascii_spelling(
     [
         (
             "experiments/agentdojo/uv.lock",
-            'version = "1.5.1"',
             'version = "1.5.2"',
+            'version = "1.5.3"',
             "experiments/agentdojo/uv.lock",
         ),
         (
             ".github/workflows/test.yml",
-            "agent_libos-1.5.1-py3-none-any.whl",
             "agent_libos-1.5.2-py3-none-any.whl",
+            "agent_libos-1.5.3-py3-none-any.whl",
             "RELEASE_WHEEL",
         ),
         (
             ".github/workflows/test.yml",
-            "agent_libos-1.5.1.tar.gz",
             "agent_libos-1.5.2.tar.gz",
+            "agent_libos-1.5.3.tar.gz",
             "RELEASE_SDIST",
         ),
         (
             "skills/swe-agent/SKILL.md",
-            "agent-libos==1.5.1",
             "agent-libos==1.5.2",
+            "agent-libos==1.5.3",
             "skills/swe-agent/SKILL.md",
         ),
         (
             "agent_libos/substrate/local.py",
-            'version="1.5.1"',
             'version="1.5.2"',
+            'version="1.5.3"',
             "MCP clientInfo",
         ),
         (
             "desktop/runtime-manifest.json",
-            '"version": "1.5.1"',
             '"version": "1.5.2"',
+            '"version": "1.5.3"',
             "desktop/runtime-manifest.json",
         ),
         (
             "scripts/check_desktop_artifacts.py",
-            'VERSION = "1.5.1"',
             'VERSION = "1.5.2"',
+            'VERSION = "1.5.3"',
             "scripts/check_desktop_artifacts.py",
         ),
         (
             "CHANGELOG.md",
-            "## 1.5.1",
             "## 1.5.2",
+            "## 1.5.3",
             "CHANGELOG.md current release",
         ),
         (
             "docs/release_status.md",
-            "Agent libOS 1.5.1 Status",
             "Agent libOS 1.5.2 Status",
+            "Agent libOS 1.5.3 Status",
             "docs/release_status.md",
         ),
     ],
@@ -251,8 +251,8 @@ def test_release_validation_rejects_desktop_artifact_name_drift(
     workflow = tmp_path / ".github" / "workflows" / "desktop-internal.yml"
     workflow.write_text(
         workflow.read_text(encoding="utf-8").replace(
-            "agent-libos-1.5.1-macos-arm64-internal-unsigned",
             "agent-libos-1.5.2-macos-arm64-internal-unsigned",
+            "agent-libos-1.5.3-macos-arm64-internal-unsigned",
         ),
         encoding="utf-8",
     )
@@ -276,7 +276,7 @@ def test_release_runbook_keeps_remote_version_uniqueness_out_of_local_checker() 
     )
     assert "re-check the complete PyPI project history" in normalized
     assert "intended remote's tags" in normalized
-    assert "pins the exact target `1.5.1`" in normalized
+    assert "pins the exact target `1.5.2`" in normalized
 
 
 def test_release_runbook_builds_local_preflight_in_a_fresh_directory() -> None:

--- a/tests/unit/test_runtime_storage_documentation_contracts.py
+++ b/tests/unit/test_runtime_storage_documentation_contracts.py
@@ -401,7 +401,7 @@ def test_data_flow_docs_pin_llm_sink_identity_and_host_result_domains() -> None:
         "changing any bound effective policy invalidates a trust rule tied to the old identity hash",
         "`prompt_cache_mode`, `prompt_cache_ttl`, or `fallback_json_actions` changes the profile identity hash",
         "trusted Sink rule bound to the old `identity_sha256` no longer matches",
-        "six built-in provider domains—Filesystem, Shell, Git, JSON-RPC, MCP, and LLM—",
+        "six provider contract namespaces (Filesystem, Shell, Git, JSON-RPC, MCP, and LLM",
     ):
         assert required in documentation
     assert "five built-in provider domains" not in documentation
@@ -411,7 +411,7 @@ def test_storage_docs_distinguish_product_and_schema_and_bound_backup_support() 
     documentation = _words(_read("docs/storage.md"))
     readme = _words(_read("README.md"))
 
-    assert "Agent libOS 1.5.1 stores durable runtime state" in documentation
+    assert "Agent libOS 1.5.2 stores durable runtime state" in documentation
     assert "## Strict store schema v7" in documentation
     assert "Product version and store schema version are independent" in documentation
     assert "The only supported migrations are the explicit, offline, operator-invoked canonical v4-to-v5, v5-to-v6, and v6-to-v7 procedures" in documentation

--- a/tests/unit/test_task_run_cli.py
+++ b/tests/unit/test_task_run_cli.py
@@ -344,6 +344,42 @@ def test_task_run_parser_exposes_the_exact_supported_subcommands() -> None:
     )
 
 
+def test_task_run_list_status_filter_is_bound_to_the_status_enum() -> None:
+    # Regression: the closed status-filter set, the --status help text, and
+    # the rejection message must all be derived from TaskRunStatus so the
+    # valid values are discoverable without reading source code.
+    from agent_libos.api.cli import _TASK_RUN_STATUSES, _task_run_status_filters
+
+    assert _TASK_RUN_STATUSES == {status.value for status in models.TaskRunStatus}
+
+    parser, _args_namespace = _parse_cli_args(["task-run", "list"])
+    task_run_action = next(
+        action
+        for action in parser._actions
+        if getattr(action, "dest", None) == "command"
+    )
+    task_run_parser = task_run_action.choices["task-run"]
+    command_action = next(
+        action
+        for action in task_run_parser._actions
+        if getattr(action, "dest", None) == "task_run_command"
+    )
+    list_parser = command_action.choices["list"]
+    status_action = next(
+        action
+        for action in list_parser._actions
+        if getattr(action, "dest", None) == "statuses"
+    )
+    for status in models.TaskRunStatus:
+        assert status.value in status_action.help
+
+    with pytest.raises(ValidationError) as excinfo:
+        _task_run_status_filters(["queued,not_a_status"])
+    assert "not_a_status" in str(excinfo.value)
+    for status in models.TaskRunStatus:
+        assert status.value in str(excinfo.value)
+
+
 def test_task_run_list_passes_bounded_status_filters_and_cursor() -> None:
     runtime = _runtime()
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-libos"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
Bump the release line to 1.5.2 across all version-bearing surfaces (pyproject, agent_libos/__init__, uv locks, GUI package, MCP clientInfo, desktop metadata, release workflows, changelog, release status, glossary, and narrative docs) and update the release-contract regression pins.

Ships the comprehensive documentation review remediation: corrected drifted MCP Resource surface, image-binding, and checkpoint inventories; documented the CLI exit-code contract and exec image-package authority grant; fixed the storage migration backup example, stale 0.3 version tokens, and broken internal anchors; pinned the PyPI README quick-start clone to the release tag; added help text for required CLI options; completed guide navigation; and added a glossary version-map/schema_version tripwire regression test.

Generated references and lockfiles regenerated from the bumped source. validate_version_alignment reports 1.5.2; unit, release-contract, and documentation-link suites pass.